### PR TITLE
docs: add SECURITY.md with private vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not report security vulnerabilities through public GitHub issues, pull requests, or the mailing list.** Public disclosure of an unpatched issue puts all users at risk.
+
+Instead, report vulnerabilities privately through GitHub's private vulnerability reporting:
+
+1. Open the **[Security tab](https://github.com/essedum-project/essedum-platform/security)** of this repository.
+2. Click **"Report a vulnerability"** to open the private advisory form.
+3. Include as much detail as you can:
+   - the affected component and version/branch,
+   - a description of the issue and its impact,
+   - steps to reproduce or a proof of concept,
+   - and any suggested remediation.
+
+Your report stays private to the maintainers until a fix is available.
+
+## What to Expect
+
+- We aim to acknowledge new reports within a few business days.
+- We will keep you updated on progress toward a fix and coordinate disclosure timing with you.
+- If a report involves **exposed credentials or secrets**, note that rotating/revoking the affected keys is required in addition to any code change — removing them from the source alone does not remediate the exposure.
+
+## Supported Versions
+
+Security fixes are prioritized for the latest release line. Older release branches may not receive security updates.
+
+## Scope
+
+Examples of issues worth reporting: authentication or authorization flaws, injection (SQL/command), server-side request forgery (SSRF), insecure deserialization, path traversal, and secrets or credentials committed to the codebase.


### PR DESCRIPTION
## What

Adds a `SECURITY.md` security policy at the repository root.

## Why

The repository has no documented security policy, so contributors and users have no clear, safe path to report a vulnerability. GitHub **private vulnerability reporting is enabled** on this repo, but nothing points people to it — leaving a public issue or mailing-list post as the likely (and unsafe) default.

This policy:
- Directs reporters to the private **Security → Report a vulnerability** flow and explicitly asks them not to use public issues/PRs or the mailing list.
- Sets expectations for acknowledgement and coordinated disclosure.
- Notes that for exposed-credential reports, rotation/revocation is required in addition to a code change (removing a secret from source does not remediate it, since it remains in history).
- Documents supported versions and reporting scope.

Documentation-only; no code impact.
