### PR TITLE
fix: validate file before closing stream in FileValidateV2 (use-after-close)

### DIFF
--- a/sv/data-service/src/main/java/com/lfn/ai/comm/lib/util/FileValidateV2.java
+++ b/sv/data-service/src/main/java/com/lfn/ai/comm/lib/util/FileValidateV2.java
@@ -206,14 +206,16 @@ public class FileValidateV2 {
 
 	private FileValidateSummary validateFile(File file, List<String> allowed,List<String> allowedFileType) throws FileNotFoundException {
 		FileInputStream inputstream = null;
+		FileValidateSummary summary;
 		try {
 			inputstream = new FileInputStream(file);
+			summary = this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(), null);
 		} finally {
 			if (inputstream != null) {
 				safeClose(inputstream);
 			}
 		}
-		return this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(),null);
+		return summary;
 	}
 
 	private FileValidateSummary validateFile(MultipartFile mulipartFile, List<String> allowed,List<String> allowedFileType,List<String>allowedMandatoryFileExtension) {

--- a/sv/icip-service/src/main/java/com/lfn/ai/comm/lib/util/FileValidateV2.java
+++ b/sv/icip-service/src/main/java/com/lfn/ai/comm/lib/util/FileValidateV2.java
@@ -206,14 +206,16 @@ public class FileValidateV2 {
 
 	private FileValidateSummary validateFile(File file, List<String> allowed,List<String> allowedFileType) throws FileNotFoundException {
 		FileInputStream inputstream = null;
+		FileValidateSummary summary;
 		try {
 			inputstream = new FileInputStream(file);
+			summary = this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(), null);
 		} finally {
 			if (inputstream != null) {
 				safeClose(inputstream);
 			}
 		}
-		return this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(),null);
+		return summary;
 	}
 
 	private FileValidateSummary validateFile(MultipartFile mulipartFile, List<String> allowed,List<String> allowedFileType,List<String>allowedMandatoryFileExtension) {

--- a/sv/usm-service/src/main/java/com/lfn/ai/comm/lib/util/FileValidateV2.java
+++ b/sv/usm-service/src/main/java/com/lfn/ai/comm/lib/util/FileValidateV2.java
@@ -206,14 +206,16 @@ public class FileValidateV2 {
 
 	private FileValidateSummary validateFile(File file, List<String> allowed,List<String> allowedFileType) throws FileNotFoundException {
 		FileInputStream inputstream = null;
+		FileValidateSummary summary;
 		try {
 			inputstream = new FileInputStream(file);
+			summary = this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(), null);
 		} finally {
 			if (inputstream != null) {
 				safeClose(inputstream);
 			}
 		}
-		return this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(),null);
+		return summary;
 	}
 
 	private FileValidateSummary validateFile(MultipartFile mulipartFile, List<String> allowed,List<String> allowedFileType,List<String>allowedMandatoryFileExtension) {

--- a/sv/vibe-service/src/main/java/com/lfn/ai/comm/lib/util/FileValidateV2.java
+++ b/sv/vibe-service/src/main/java/com/lfn/ai/comm/lib/util/FileValidateV2.java
@@ -206,14 +206,16 @@ public class FileValidateV2 {
 
 	private FileValidateSummary validateFile(File file, List<String> allowed,List<String> allowedFileType) throws FileNotFoundException {
 		FileInputStream inputstream = null;
+		FileValidateSummary summary;
 		try {
 			inputstream = new FileInputStream(file);
+			summary = this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(), null);
 		} finally {
 			if (inputstream != null) {
 				safeClose(inputstream);
 			}
 		}
-		return this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(),null);
+		return summary;
 	}
 
 	private FileValidateSummary validateFile(MultipartFile mulipartFile, List<String> allowed,List<String> allowedFileType,List<String>allowedMandatoryFileExtension) {


### PR DESCRIPTION
## What

Fixes a use-after-close bug in the 3-argument `validateFile(File, List, List)` overload of `FileValidateV2`, in all four backend services (`usm-service`, `icip-service`, `data-service`, `vibe-service`).

## The bug

The method opened a `FileInputStream`, closed it in `finally`, and **then** passed the already-closed stream to the 5-argument `validateFile(...)` that reads from it:

```java
try {
    inputstream = new FileInputStream(file);
} finally {
    if (inputstream != null) safeClose(inputstream);   // closed here
}
return this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(), null); // read after close
```

The validation therefore runs against a closed stream.

## The fix

Move the validation call inside the `try` (before the stream is closed), matching the pattern already used by the correct 6-argument overload in the same class:

```java
try {
    inputstream = new FileInputStream(file);
    summary = this.validateFile(inputstream, allowed, allowedFileType, 0, file.getName(), null);
} finally {
    if (inputstream != null) safeClose(inputstream);
}
return summary;
```

## Verification

`mvn compile` on `icip-service` passes on JDK 21.
