### PR TITLE
fix: compare Strings with equals() instead of == (dead branches)

### DIFF
--- a/sv/data-service/src/main/java/com/lfn/iamp/usm/web/rest/EmailResource.java
+++ b/sv/data-service/src/main/java/com/lfn/iamp/usm/web/rest/EmailResource.java
@@ -225,7 +225,7 @@ public class EmailResource {
 			PageRequestCustomOffset pagerequest;
 			List<EmailPartialDTO> emails = List.of();
 			
-			if(source == "enduser") {
+			if("enduser".equals(source)) {
 				if(offset == true) {
 					pagerequest = new PageRequestCustomOffset(pageable.getPageNumber(),pageable.getPageSize(), pageable.getSort());
 					emails = emailService.findByEndUser(user_email, pagerequest);

--- a/sv/data-service/src/main/java/com/lfn/icip/icipwebeditor/service/impl/ICIPPipelineService.java
+++ b/sv/data-service/src/main/java/com/lfn/icip/icipwebeditor/service/impl/ICIPPipelineService.java
@@ -827,7 +827,7 @@ public class ICIPPipelineService implements IICIPSearchable{
 					joblogger.error(marker, "Error in importing duplicate nativeScript {}",nativeS.getCname());
 				}
 			});
-			if(interfacetype == "App") {
+			if("App".equals(interfacetype)) {
 				appService.importData(marker, target, jsonObject.getJSONObject("appdetails"));
 			}
 			joblogger.info(marker, "Imported {} successfully", interfacetype);

--- a/sv/icip-service/src/main/java/com/lfn/iamp/usm/web/rest/EmailResource.java
+++ b/sv/icip-service/src/main/java/com/lfn/iamp/usm/web/rest/EmailResource.java
@@ -225,7 +225,7 @@ public class EmailResource {
 			PageRequestCustomOffset pagerequest;
 			List<EmailPartialDTO> emails = List.of();
 			
-			if(source == "enduser") {
+			if("enduser".equals(source)) {
 				if(offset == true) {
 					pagerequest = new PageRequestCustomOffset(pageable.getPageNumber(),pageable.getPageSize(), pageable.getSort());
 					emails = emailService.findByEndUser(user_email, pagerequest);

--- a/sv/icip-service/src/main/java/com/lfn/icip/icipwebeditor/service/impl/ICIPPipelineService.java
+++ b/sv/icip-service/src/main/java/com/lfn/icip/icipwebeditor/service/impl/ICIPPipelineService.java
@@ -827,7 +827,7 @@ public class ICIPPipelineService implements IICIPSearchable{
 					joblogger.error(marker, "Error in importing duplicate nativeScript {}",nativeS.getCname());
 				}
 			});
-			if(interfacetype == "App") {
+			if("App".equals(interfacetype)) {
 				appService.importData(marker, target, jsonObject.getJSONObject("appdetails"));
 			}
 			joblogger.info(marker, "Imported {} successfully", interfacetype);

--- a/sv/usm-service/src/main/java/com/lfn/iamp/usm/web/rest/EmailResource.java
+++ b/sv/usm-service/src/main/java/com/lfn/iamp/usm/web/rest/EmailResource.java
@@ -225,7 +225,7 @@ public class EmailResource {
 			PageRequestCustomOffset pagerequest;
 			List<EmailPartialDTO> emails = List.of();
 			
-			if(source == "enduser") {
+			if("enduser".equals(source)) {
 				if(offset == true) {
 					pagerequest = new PageRequestCustomOffset(pageable.getPageNumber(),pageable.getPageSize(), pageable.getSort());
 					emails = emailService.findByEndUser(user_email, pagerequest);

--- a/sv/vibe-service/src/main/java/com/lfn/iamp/usm/web/rest/EmailResource.java
+++ b/sv/vibe-service/src/main/java/com/lfn/iamp/usm/web/rest/EmailResource.java
@@ -225,7 +225,7 @@ public class EmailResource {
 			PageRequestCustomOffset pagerequest;
 			List<EmailPartialDTO> emails = List.of();
 			
-			if(source == "enduser") {
+			if("enduser".equals(source)) {
 				if(offset == true) {
 					pagerequest = new PageRequestCustomOffset(pageable.getPageNumber(),pageable.getPageSize(), pageable.getSort());
 					emails = emailService.findByEndUser(user_email, pagerequest);


### PR DESCRIPTION
## What

Replaces reference comparison (`==`) of `String` values with content comparison (`.equals(...)`) in two places, across the affected backend services.

## The bug

`==` on `String` compares object references, not contents. For request-derived strings (which are not interned), it is effectively always `false`, so the guarded branch never runs.

**1. `EmailResource`** (`usm-service`, `icip-service`, `data-service`, `vibe-service`) — `source` is a `@PathVariable String`:
```diff
- if(source == "enduser") {
+ if("enduser".equals(source)) {
```
The `enduser` branch (which builds the end-user email query) was effectively unreachable.

**2. `ICIPPipelineService`** (`data-service`, `icip-service`):
```diff
- if(interfacetype == "App") {
+ if("App".equals(interfacetype)) {
```

Putting the literal on the left (`"enduser".equals(source)`) also makes the check null-safe.

## Verification

`mvn compile` on `icip-service` (which contains both files) passes on JDK 21.

## Note

This makes a previously-unreachable branch execute as originally intended. If any downstream behavior was relying on the branch never running, please flag it in review.
