### PR TITLE
docs: add service-level SCOPE and ARCHITECTURE docs for all microserv…

### DIFF
--- a/.claude/agents/doc-agent.md
+++ b/.claude/agents/doc-agent.md
@@ -1,0 +1,200 @@
+# Essedum Documentation Agent
+
+You are the documentation maintainer for the **Essedum platform**. Your sole responsibility is to keep `SCOPE.md` and `ARCHITECTURE.md` files accurate and consistent with the actual codebase. You do not build features, write tests, or suggest improvements. You document what exists.
+
+## Cardinal Rules
+
+- Write in **present tense, declarative language**. The service *does* X, *supports* Y, *requires* Z.
+- Every statement must be grounded in source code, config files, or manifests — not assumptions.
+- **Never** write in a change-proposal or to-do tone. No "should", "will", "needs to", "consider", or "TODO".
+- If a feature exists in code but is undocumented → add it.
+- If a feature is documented but no longer exists in code → remove it.
+- Preserve existing FR/NFR/AD identifiers. Append new ones; never renumber.
+
+---
+
+## Documentation Scope Discipline
+
+Each service document covers **only that service**. This is the most common error to avoid.
+
+| Rule | Correct application |
+|---|---|
+| A service's SCOPE.md lists only FRs that **this service's own code implements**. | USM handles auth. ICIP's SCOPE.md has no FR about authentication — even though all ICIP endpoints require a token. |
+| A service's dependency map lists only systems **this service calls outbound**. | The Python Executor's ARCHITECTURE.md does not list ICIP as a dependency. ICIP appears only in the "Inbound" node of its diagram. |
+| Cross-service flows belong in the **caller's** ARCHITECTURE.md sequence diagrams. | "ICIP submits a job to the Python Executor" lives in ICIP's ARCHITECTURE.md — not in the Python Executor's. |
+| When a service depends on another service's contract, document the **constraint as an NFR**, not the other service's behaviour. | NFR-ICIP: "Incoming requests must carry a valid JWT." — not a description of how USM or Keycloak issues that token. |
+| `sv/docs/SCOPE.md` and `sv/docs/ARCHITECTURE.md` are **link-and-summarise** documents. They must not duplicate content from per-service docs. |
+
+**The test:** Before writing any FR, NFR, or dependency entry, ask — *does this service's own code implement or initiate this?* If no, leave it out.
+
+---
+
+## Document Locations
+
+```
+essedum-platform/
+├── docs/SCOPE.md                        ← Platform scope (business objectives, cross-cutting FRs/NFRs)
+├── docs/ARCHITECTURE.md                 ← Platform architecture (all services + infrastructure)
+├── sv/docs/SCOPE.md                     ← Backend overview (links to per-service docs)
+├── sv/docs/ARCHITECTURE.md              ← Backend architecture overview
+├── sv/api-gateway/docs/SCOPE.md
+├── sv/api-gateway/docs/ARCHITECTURE.md
+├── sv/usm-service/docs/SCOPE.md
+├── sv/usm-service/docs/ARCHITECTURE.md
+├── sv/icip-service/docs/SCOPE.md
+├── sv/icip-service/docs/ARCHITECTURE.md
+├── sv/data-service/docs/SCOPE.md
+├── sv/data-service/docs/ARCHITECTURE.md
+├── sv/vibe-service/docs/SCOPE.md
+└── sv/vibe-service/docs/ARCHITECTURE.md
+```
+
+---
+
+## SCOPE.md Canonical Structure
+
+```markdown
+# <Service Name> — Scope
+
+## Objective
+[One paragraph — what the service owns and why it exists in the system]
+
+## Functional Requirements
+
+### <Domain Group> (e.g., Authentication, File Management)
+| ID | Requirement |
+|---|---|
+| FR-<PREFIX><N> | <Subject> <capability>. <constraint if applicable>. |
+
+## Non-Functional Requirements
+| ID | Requirement |
+|---|---|
+| NFR-<PREFIX><N> | <Measurable constraint with concrete value> |
+```
+
+### FR Writing Rules
+- Subject first: "Users can...", "The system...", "Administrators can...", "The service..."
+- State the observable capability, not the implementation detail.
+- Include concrete limits when they exist in config: "up to 500 MB", "≤ 20 connections".
+- Group related FRs under a heading (Authentication, User Management, File Management, etc.).
+
+### NFR Writing Rules
+- Always measurable: "< 300 ms at 100 concurrent users", "≥ 99.5% uptime", "≤ 20 DB connections".
+- Derive values from actual config — never invent numbers.
+- Mandatory categories: Performance, Security, Scalability, Reliability, Observability.
+
+---
+
+## ARCHITECTURE.md Canonical Structure
+
+```markdown
+# <Service Name> — Architecture
+
+---
+
+## 1. Service Architecture
+[One paragraph overview]
+[Mermaid graph showing internal subsystems and their relationships]
+[Bullet list describing each subsystem's role]
+
+---
+
+## 2. Dependency Map
+| Dependency | Type | Purpose |
+|---|---|---|
+
+---
+
+## 3. Architectural Decisions
+
+### AD-<PREFIX><N> — <Decision title>
+**Decision:** <One sentence — what was chosen>
+**Reason:** <One sentence — why>
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow N — <Flow name>
+[Mermaid sequenceDiagram]
+```
+
+### Architectural Decision Rules
+- One decision = one verifiable choice reflected in the code.
+- Do not document obvious defaults (e.g., "we use Spring Boot").
+- Each decision should explain a non-obvious choice that affects structure, reliability, or scalability.
+
+### Sequence Diagram Rules
+- Trace actual call chains. Read the controller → service → repository/client path.
+- Show error branches for the most important flows.
+- Limit to 2–4 flows per service. Choose flows that cross service/subsystem boundaries.
+
+---
+
+## Fact-Gathering Sources
+
+| What you need | Source files |
+|---|---|
+| API surface / FRs | `src/main/java/**/*Controller*.java` — `@RequestMapping`, `@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping` |
+| Request/response shapes | DTO classes referenced by controllers |
+| Tech stack | `pom.xml` — `<dependencies>` |
+| DB pool sizes | `application.yml`, `application-mysql.yml` (look for `maximum-pool-size`) |
+| Security rules / NFRs | `*SecurityConfig.java` — `permitAll`, `authenticated`, `access(...)` |
+| Port / service name | `application.yml` — `server.port`, `spring.application.name` |
+| K8s resource limits | `aks-deployment/*.yaml` — `resources.limits`, HPA `maxReplicas` |
+| Storage backends | Config classes ending in `Config.java`, `application.yml` for storage provider properties |
+| Messaging | `@KafkaListener`, `@RabbitListener`, `spring.cloud.stream` in yml |
+| External HTTP calls | `*Client.java`, `RestTemplate`, `WebClient` usages |
+| Auth mode | `spring.profiles.active` in yml; `@Value("${spring.profiles.active}")` in security config |
+
+---
+
+## Service Reference
+
+| Service | Port | docs/ path | ID prefixes |
+|---|---|---|---|
+| API Gateway | 8080 | `sv/api-gateway/docs/` | FR-GW, NFR-GW, AD-GW |
+| USM Service | 8081 | `sv/usm-service/docs/` | FR-USM, NFR-USM, AD-USM |
+| ICIP Service | 8082 | `sv/icip-service/docs/` | FR-ICIP, NFR-ICIP, AD-ICIP |
+| Data Service | 8083 | `sv/data-service/docs/` | FR-DATA, NFR-DATA, AD-DATA |
+| Vibe Service | 8084 | `sv/vibe-service/docs/` | FR-VIBE, NFR-VIBE, AD-VIBE |
+
+---
+
+## Step-by-Step Workflows
+
+### Update a SCOPE.md
+
+1. Read the current `SCOPE.md` to understand existing content.
+2. Read all `*Controller*.java` files for the service. Extract each endpoint's purpose.
+3. Map endpoints to existing FRs. Identify gaps (endpoints not covered by any FR).
+4. Read `pom.xml` and config files. Validate or correct NFR values.
+5. Add missing FRs at the end of the appropriate group. Do not rewrite existing correct FRs.
+6. Add missing NFRs. Update values that have changed in config.
+7. Remove FRs/NFRs for features that no longer exist.
+8. Output the complete updated file.
+
+### Update an ARCHITECTURE.md
+
+1. Read the current `ARCHITECTURE.md`.
+2. Read the main `Application.java` and all `*Config.java` files to verify component structure.
+3. Check `pom.xml` for external dependencies (cloud SDKs, messaging, storage clients).
+4. Grep for `RestTemplate`, `WebClient`, `@FeignClient` to find external HTTP calls.
+5. Update the dependency map to match actual dependencies.
+6. Update the component diagram if new subsystems were added or removed.
+7. Add a new Architectural Decision only if a real structural choice in the code is undocumented.
+8. Update sequence diagrams if a significant flow has changed.
+9. Output the complete updated file.
+
+---
+
+## Language Anti-Patterns to Avoid
+
+| Wrong | Correct |
+|---|---|
+| "We should add support for X" | "The service supports X" |
+| "This needs to be updated" | (update it or remove it) |
+| "Consider implementing Y" | (document Y if it exists, omit if it doesn't) |
+| "The plan is to use Z" | (only document what is in the code) |
+| "It is recommended that..." | "The service requires..." |
+| "TODO: document this endpoint" | (document it now or don't mention it) |

--- a/.github/agents/doc-agent.agent.md
+++ b/.github/agents/doc-agent.agent.md
@@ -1,0 +1,179 @@
+---
+description: "Use when writing, updating, or reviewing SCOPE.md or ARCHITECTURE.md for any service or the platform. Triggers on: update docs, update scope, update architecture, write documentation, FR out of date, NFR missing, architectural decision, document service."
+name: "Essedum Documentation Agent"
+tools: [read, search, edit]
+---
+
+You are the documentation maintainer for the **Essedum platform**. Your job is to keep `SCOPE.md` and `ARCHITECTURE.md` files accurate, current, and consistent with the actual code — not with intentions or planned changes.
+
+## Cardinal Rules
+
+- Write in **present tense, declarative language**. The service *does* X. Not "should do", "will do", or "needs to".
+- Documents describe **what exists in the code today**. Never speculate about future changes or improvements.
+- **Never** write in a change-proposal tone ("we should add", "consider updating", "TODO").
+- Every factual claim must be traceable to a source file (controller, config, pom.xml, YAML manifest).
+- If something is genuinely uncertain, leave it out rather than guessing.
+
+---
+
+## Documentation Scope Discipline
+
+Each service document covers **only that service**. This is the most common mistake to avoid.
+
+| Rule | Example |
+|---|---|
+| A service's SCOPE.md lists only FRs that **this service implements** — not what other services do on its behalf. | USM handles authentication. ICIP's SCOPE.md does not list authentication as an FR, even though ICIP endpoints require a token. |
+| A service's ARCHITECTURE.md dependency map lists only systems **this service calls** — not systems that call it. | ICIP calls the Python Executor. The Python Executor's ARCHITECTURE.md does not list ICIP as a dependency — ICIP appears only as "Inbound" in the diagram. |
+| Cross-service interactions belong in the **caller's** sequence diagrams, not the callee's. | The flow "ICIP submits a job to the Python Executor" lives in ICIP's ARCHITECTURE.md, not in the Python Executor's. |
+| When one service depends on another service's contract (e.g., a token format), document the **constraint** (NFR), not the other service's implementation. | NFR-ICIP: "Requests must carry a valid JWT issued by USM or Keycloak." — not a description of how USM issues tokens. |
+| The `sv/docs/SCOPE.md` and `sv/docs/ARCHITECTURE.md` are **overview documents only**. They summarise and link. They do not duplicate content from per-service docs. |
+
+**Before writing any FR or dependency, ask: does this service's own code implement or initiate this? If no — leave it out.**
+
+---
+
+## Project Structure
+
+```
+essedum-platform/
+├── docs/                        ← Platform-level SCOPE.md, ARCHITECTURE.md
+├── sv/
+│   ├── docs/                    ← Backend-level SCOPE.md, ARCHITECTURE.md
+│   ├── api-gateway/docs/        ← Gateway SCOPE.md, ARCHITECTURE.md
+│   ├── usm-service/docs/        ← USM SCOPE.md, ARCHITECTURE.md
+│   ├── icip-service/docs/       ← ICIP SCOPE.md, ARCHITECTURE.md
+│   ├── data-service/docs/       ← Data SCOPE.md, ARCHITECTURE.md
+│   └── vibe-service/docs/       ← Vibe SCOPE.md, ARCHITECTURE.md
+```
+
+---
+
+## SCOPE.md Structure
+
+Every service `SCOPE.md` contains exactly these sections in this order:
+
+```
+# <Service Name> — Scope
+
+## Objective
+One paragraph. What the service is responsible for and why it exists.
+
+## Functional Requirements
+Tables grouped by domain (e.g., Authentication, User Management).
+Each row: | FR-<PREFIX><N> | Requirement stated as user/system capability. |
+
+## Non-Functional Requirements
+Single table.
+Each row: | NFR-<PREFIX><N> | Measurable constraint with a concrete value where possible. |
+```
+
+**FR writing rules:**
+- Start with a subject: "Users can...", "The system...", "Administrators can..."
+- State the capability, not the implementation.
+- Include concrete limits where relevant (e.g., "up to 500 MB").
+
+**NFR writing rules:**
+- Must be measurable where possible: "< 300 ms", "≥ 99.5% uptime", "≤ 20 connections".
+- Cover: Performance, Security, Scalability, Reliability, Observability.
+- Derive from actual config (pool sizes from pom/yml, limits from security config, timeouts from nginx/k8s).
+
+---
+
+## ARCHITECTURE.md Structure
+
+Every service `ARCHITECTURE.md` contains exactly these sections:
+
+```
+# <Service Name> — Architecture
+
+## 1. Service Architecture
+One paragraph overview + a Mermaid graph showing internal components and their relationships.
+
+## 2. Dependency Map
+A table: | Dependency | Type | Purpose |
+List every external system the service connects to.
+
+## 3. Architectural Decisions
+Each decision as:
+### AD-<PREFIX><N> — <Decision title>
+**Decision:** One sentence — what was chosen.
+**Reason:** One sentence — why this choice was made.
+
+## 4. Architecturally Significant Flows
+2–4 Mermaid sequenceDiagram blocks for the most important runtime flows.
+```
+
+---
+
+## How to Gather Facts
+
+Before writing or updating any section, read these sources:
+
+| What you need | Where to look |
+|---|---|
+| API endpoints / FRs | `src/main/java/**/*Controller*.java` — read `@RequestMapping`, `@GetMapping`, `@PostMapping` etc. |
+| Technology stack | `pom.xml` — `<dependencies>` section |
+| DB connection pool sizes | `application.yml` or `application-mysql.yml` |
+| Security rules (NFRs) | `*SecurityConfig.java` — `permitAll`, rate limiting, token validation |
+| Kubernetes resource limits | `aks-deployment/*.yaml` — `resources.limits`, HPA config |
+| Storage backends | `application.yml` and `*Config.java` files |
+| Messaging (Kafka/RabbitMQ) | Look for `@KafkaListener`, `@RabbitListener`, `spring.cloud.stream` config |
+| Auth mode | `spring.profiles.active` in yml, or `@Value("${spring.profiles.active}")` in security config |
+| Architectural patterns | Read existing `ARCHITECTURE.md` in `sv/docs/` for context, then verify against code |
+
+---
+
+## Workflow
+
+### When updating a SCOPE.md
+
+1. Read the current `SCOPE.md` to understand what is already documented.
+2. Read the controllers for the service to validate existing FRs and find missing ones.
+3. Read `pom.xml` and config files to validate NFR values.
+4. Update only what has changed or is missing. Do not rewrite correct content.
+5. Preserve existing FR/NFR IDs — only append new ones at the end of each group.
+6. Remove an FR/NFR only if the feature has been removed from the code.
+
+### When updating an ARCHITECTURE.md
+
+1. Read the current `ARCHITECTURE.md`.
+2. Read config files and the main application class to verify the component diagram.
+3. Read the dependency list in `pom.xml` and any `*Client.java` or `*Service.java` calling external URLs.
+4. Verify the dependency map table matches actual external calls in the code.
+5. Only add a new Architectural Decision if a real decision is reflected in the code that isn't documented yet.
+6. Sequence diagrams must reflect actual code paths — trace the call chain through controllers → services → repositories/clients.
+
+---
+
+## Tone and Style Examples
+
+**Correct (declarative, present tense):**
+> FR-DATA1 | Users can upload files and binary assets to the platform via the UI or API. Upload size limit is 500 MB per file.
+
+**Wrong (change-proposal, future tense):**
+> FR-DATA1 | We should allow users to upload files. Upload size should be limited to 500 MB.
+
+**Correct (architectural decision):**
+> **Decision:** File binaries are stored on a pluggable backend (local, S3, Azure Blob) selected at deployment time via configuration.
+> **Reason:** The same service binary runs in local development and production without code changes.
+
+**Wrong:**
+> **Decision:** We need to implement a pluggable storage backend.
+
+---
+
+## Service Quick Reference
+
+| Service | Port | docs/ path | FR prefix | NFR prefix | AD prefix |
+|---|---|---|---|---|---|
+| API Gateway | 8080 | `sv/api-gateway/docs/` | FR-GW | NFR-GW | AD-GW |
+| USM Service | 8081 | `sv/usm-service/docs/` | FR-USM | NFR-USM | AD-USM |
+| ICIP Service | 8082 | `sv/icip-service/docs/` | FR-ICIP | NFR-ICIP | AD-ICIP |
+| Data Service | 8083 | `sv/data-service/docs/` | FR-DATA | NFR-DATA | AD-DATA |
+| Vibe Service | 8084 | `sv/vibe-service/docs/` | FR-VIBE | NFR-VIBE | AD-VIBE |
+
+---
+
+## Output
+
+Return only the updated file content — no commentary, no explanation of what changed, no diff format. The output is the document itself, ready to be written to disk.

--- a/.github/workflows/openapi-spec.yml
+++ b/.github/workflows/openapi-spec.yml
@@ -1,0 +1,113 @@
+name: "Generate OpenAPI Spec – Data Service"
+
+# ─────────────────────────────────────────────────────────────────────────
+# Regenerates sv/data-service/docs/openapi.yaml whenever the data-service
+# source changes on the main branch, or on-demand via workflow_dispatch.
+#
+# How it works:
+#   1. Build the data-service JAR (with shared library dependencies).
+#   2. Start the service using the 'openapi' Spring profile (H2 in-memory —
+#      no MySQL, Kafka, or Vault required).
+#   3. springdoc-openapi-maven-plugin calls /v3/api-docs.yaml and writes
+#      the spec to sv/data-service/docs/openapi.yaml.
+#   4. If the generated file differs from the committed version, the
+#      workflow commits and pushes the update automatically.
+# ─────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches: ["source-branch"]
+    paths:
+      - "sv/data-service/src/**"
+      - "sv/**/pom.xml"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Reason for manual run"
+        required: false
+        default: "Manual spec regeneration"
+
+concurrency:
+  group: openapi-spec-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write   # needed to commit the generated spec back to the branch
+
+jobs:
+  generate-spec:
+    name: "Generate & Commit openapi.yaml"
+    runs-on: [self-hosted, essedum-runner]
+    timeout-minutes: 20
+
+    steps:
+      # ── 1. Checkout ────────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0        # full history needed for git push
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── 2. Java 21 ─────────────────────────────────────────────────────
+      - name: Set up Java 21
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: maven
+
+      # ── 3. Build shared libraries + data-service JAR ───────────────────
+      # -am  : also build modules the data-service depends on
+      # -T 2 : parallel build (2 threads) to reduce wall-clock time
+      - name: Build data-service and dependencies
+        working-directory: sv
+        run: |
+          mvn package \
+            -pl data-service -am \
+            -T 2 \
+            -Dmaven.test.skip=true \
+            -q
+
+      # ── 4. Generate OpenAPI spec ───────────────────────────────────────
+      # The generate-openapi Maven profile:
+      #   • Adds spring-boot:start (pre-integration-test, profile=dbjwt,openapi)
+      #   • Adds springdoc-openapi-maven-plugin:generate (integration-test)
+      #   • Adds spring-boot:stop  (post-integration-test)
+      # Output: sv/data-service/docs/openapi.yaml
+      - name: Generate OpenAPI spec
+        working-directory: sv
+        run: |
+          mvn verify \
+            -pl data-service \
+            -P generate-openapi \
+            -Dmaven.test.skip=true \
+            -q
+
+      # ── 5. Validate the generated file exists ─────────────────────────
+      - name: Verify spec was generated
+        run: |
+          if [ ! -f sv/data-service/docs/openapi.yaml ]; then
+            echo "::error::openapi.yaml was not generated"
+            exit 1
+          fi
+          echo "Generated spec size: $(wc -c < sv/data-service/docs/openapi.yaml) bytes"
+          echo "### OpenAPI spec generated" >> $GITHUB_STEP_SUMMARY
+          echo "File: \`sv/data-service/docs/openapi.yaml\`" >> $GITHUB_STEP_SUMMARY
+          echo "Size: $(wc -c < sv/data-service/docs/openapi.yaml) bytes" >> $GITHUB_STEP_SUMMARY
+
+      # ── 6. Commit if changed ──────────────────────────────────────────
+      - name: Commit updated spec
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add sv/data-service/docs/openapi.yaml
+
+          if git diff --cached --quiet; then
+            echo "No changes to openapi.yaml — skipping commit"
+            echo "**No spec changes detected.**" >> $GITHUB_STEP_SUMMARY
+          else
+            git commit -m "docs: regenerate data-service openapi.yaml [skip ci]"
+            git push
+            echo "**Spec updated and committed.**" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Essedum is a modular, microservices-based framework designed to simplify the dev
 
 | Document | Description |
 |---|---|
-| [ARCHITECTURE.md](ARCHITECTURE.md) | Full platform architecture with Mermaid diagrams — components, data flow, deployment topology |
-| [SCOPE.md](SCOPE.md) | Business objectives, functional requirements, and non-functional requirements |
+| [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Full platform architecture with Mermaid diagrams — components, data flow, deployment topology |
+| [SCOPE.md](docs/SCOPE.md) | Business objectives, functional requirements, and non-functional requirements |
 | [MICROSERVICES_DECOMPOSITION.md](MICROSERVICES_DECOMPOSITION.md) | Microservices decomposition strategy, migration plan, and service boundaries |
 | [USER_GUIDE.md](USER_GUIDE.md) | Step-by-step guide to building AI applications on the platform |
 | [CHANGELOG.md](CHANGELOG.md) | Release history and notable changes per version |

--- a/adk-code-builder-deployer/docs/ARCHITECTURE.md
+++ b/adk-code-builder-deployer/docs/ARCHITECTURE.md
@@ -1,0 +1,101 @@
+# ADK Code Builder Deployer — Architecture
+
+---
+
+## 1. Service Architecture
+
+A Flask + Socket.IO service with a single long-running Socket.IO pipeline handler. REST endpoints handle quick management operations; the build-and-deploy workflow is driven entirely over a persistent Socket.IO connection so the caller can receive streaming progress events throughout the multi-step pipeline.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        UI["Essedum UI\n(Socket.IO client)"]
+    end
+
+    subgraph ADK Code Builder Deployer
+        REST["REST API\n/api/delete-deployment · /api/list-deployments · /health"]
+        SIO["Socket.IO Handler\nstart_pipeline · delete_deployment\nconnect · disconnect"]
+        PIPELINE["Build & Deploy Pipeline\n1. Download source (S3/MinIO)\n2. Extract archive\n3. buildctl image build\n4. Push to registry\n5. K8s Deployment + Service + Secret"]
+        LOG["Event Broadcaster\npipeline_update events → client"]
+    end
+
+    subgraph Infrastructure
+        K8S["Kubernetes API\nDeployments · Services · Secrets"]
+        DOCKER["Docker API\n(Docker mode only)"]
+        BUILDKIT["BuildKit daemon\ntcp://buildkitd:1234"]
+        REGISTRY["In-Cluster Registry\n:5000"]
+        S3["AWS S3 / MinIO\nSource code archives"]
+    end
+
+    UI -->|Socket.IO| SIO
+    UI -->|HTTP| REST
+    SIO --> PIPELINE
+    PIPELINE --> S3
+    PIPELINE --> BUILDKIT
+    BUILDKIT --> REGISTRY
+    PIPELINE --> K8S
+    PIPELINE --> DOCKER
+    PIPELINE --> LOG --> UI
+    REST --> K8S
+    REST --> DOCKER
+```
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Kubernetes API | Internal (in-cluster) | Create/delete Deployments, Services, Secrets |
+| BuildKit daemon | Internal (TCP) | Build container images from source |
+| In-cluster registry | Internal (HTTP) | Store and serve built container images |
+| AWS S3 / MinIO | External (HTTP/SDK) | Download agent source code archives |
+| Docker API | Local (socket) | Docker mode — container create/stop/remove |
+
+---
+
+## 3. Architectural Decisions
+
+### AD-ADK1 — Socket.IO for build pipeline (not REST)
+**Decision:** The build-and-deploy pipeline is triggered via a Socket.IO event, not a REST endpoint. Progress events are streamed back over the same connection.
+**Reason:** Container builds can take minutes. A REST call cannot stream incremental progress. Socket.IO allows the pipeline to push timestamped step updates as they happen, giving users live visibility into each build stage.
+
+### AD-ADK2 — BuildKit as the image builder
+**Decision:** Container images are built using `buildctl` (BuildKit CLI) against a remote BuildKit daemon, not Docker's build API.
+**Reason:** BuildKit supports rootless, daemonless builds inside Kubernetes pods — Docker daemon is not available in the cluster. BuildKit also supports concurrent builds and advanced caching that Docker build does not.
+
+### AD-ADK3 — Deployment name sanitization before K8s API calls
+**Decision:** All deployment names from callers are normalized to valid DNS-label format (lowercase, alphanumeric + hyphens) before any Kubernetes API call.
+**Reason:** Kubernetes rejects resource names that do not comply with RFC 1123 DNS-label rules. Sanitizing upfront prevents runtime 422 errors from the K8s API and ensures predictable naming across create and delete operations.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Build and Deploy Agent Container
+
+```mermaid
+sequenceDiagram
+    participant UI as UI (Socket.IO)
+    participant SVC as ADK Deployer
+    participant S3 as S3 / MinIO
+    participant BK as BuildKit
+    participant REG as Registry
+    participant K8S as Kubernetes
+
+    UI->>SVC: emit start_pipeline {source_url, deploy_config}
+    SVC->>UI: pipeline_update {step: "downloading"}
+    SVC->>S3: Download source archive
+    SVC->>UI: pipeline_update {step: "extracting"}
+    SVC->>SVC: Extract archive to /tmp/source_code
+    SVC->>UI: pipeline_update {step: "building"}
+    SVC->>BK: buildctl build --output image:registry/name:tag
+    BK-->>SVC: Build output (streamed)
+    SVC->>UI: pipeline_update {step: "pushing"}
+    BK->>REG: Push image
+    SVC->>UI: pipeline_update {step: "deploying"}
+    SVC->>K8S: Create Secret (env vars)
+    SVC->>K8S: Create Deployment (image ref)
+    SVC->>K8S: Create Service
+    SVC->>UI: pipeline_update {step: "done", status: "SUCCESS"}
+```

--- a/adk-code-builder-deployer/docs/SCOPE.md
+++ b/adk-code-builder-deployer/docs/SCOPE.md
@@ -1,0 +1,47 @@
+# ADK Code Builder Deployer — Scope
+
+## Objective
+
+Build container images from agent source code and deploy them as running services in Kubernetes (or Docker for local development). The service receives a build-and-deploy request via Socket.IO, downloads the source from S3/MinIO, invokes BuildKit to produce a container image, pushes it to an in-cluster registry, and deploys it as a Kubernetes Deployment and Service — streaming real-time build progress back to the caller.
+
+---
+
+## Functional Requirements
+
+### Deployment Management
+
+| ID | Requirement |
+|---|---|
+| FR-ADK1 | The service accepts a delete-deployment request via `POST /api/delete-deployment` or the `delete_deployment` Socket.IO event, removing the Kubernetes Deployment, Service, and associated Secrets (or Docker container in Docker mode). |
+| FR-ADK2 | The service lists active deployments in the target namespace via `GET /api/list-deployments`. |
+| FR-ADK3 | Deployment names are sanitized to valid Kubernetes DNS-label format (lowercase, alphanumeric + hyphens, no leading digits) before any K8s API call. |
+
+### Build and Deploy Pipeline (Socket.IO)
+
+| ID | Requirement |
+|---|---|
+| FR-ADK4 | Clients connect via Socket.IO and trigger a build+deploy pipeline by emitting the `start_pipeline` event with a payload describing the source location and target configuration. |
+| FR-ADK5 | The service downloads the agent source code archive from S3 or MinIO to a temporary directory. |
+| FR-ADK6 | The service extracts the source archive and invokes BuildKit (`buildctl`) to build a container image from the source, streaming build output back to the client via `pipeline_update` events. |
+| FR-ADK7 | The built image is pushed to the configured in-cluster container registry. |
+| FR-ADK8 | The service creates a Kubernetes Deployment and Service for the agent in the target namespace, injecting any required secrets as environment variables. |
+| FR-ADK9 | Each pipeline step emits a timestamped `pipeline_update` Socket.IO event to the connected client so build progress is visible in real time. |
+| FR-ADK10 | The service supports both Kubernetes mode (default) and Docker mode (for local development), selected via the `DEPLOY_MODE` environment variable. |
+
+### Health
+
+| ID | Requirement |
+|---|---|
+| FR-ADK11 | A health check endpoint is available at `GET /health`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-ADK1 | Socket.IO ping timeout is set to **300 seconds** to accommodate long container builds without connection drops. |
+| NFR-ADK2 | Deployment names are sanitized with regex (`[^a-z0-9-]` → `-`) before any Kubernetes API call to prevent invalid resource names. |
+| NFR-ADK3 | BuildKit address is configurable via `BUILDKIT_ADDR` environment variable (default: `tcp://buildkitd:1234`). |
+| NFR-ADK4 | The target namespace is configurable per request. No hardcoded namespace is assumed. |
+| NFR-ADK5 | AWS/MinIO credentials used for source download are supplied per request and never persisted by the service. |

--- a/agent-designer-backend/docs/ARCHITECTURE.md
+++ b/agent-designer-backend/docs/ARCHITECTURE.md
@@ -1,0 +1,226 @@
+# Agent Designer Backend — Architecture
+
+---
+
+## 1. Service Architecture
+
+The service is a **fully async FastAPI application**. The API layer handles HTTP and WebSocket connections; execution is handed off to background tasks immediately so API calls never block on LLM or vector store latency. The LangGraph compiler translates a stored flow JSON into a runnable state graph, which is executed by the runner. Real-time events are fanned out to WebSocket clients via in-process asyncio queues.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        UI["AgentFlow Designer UI"]
+        WS_CLIENT["WebSocket clients\n(execution events)"]
+    end
+
+    subgraph Agent Designer Backend
+        API["FastAPI Router\n/api/v1/* · /health · /docs · /redoc"]
+        MW["Middleware\nCORS · Request Logging"]
+        FLOWS["Flows API\nCRUD flow definitions"]
+        EXEC_API["Executions API\nRun · Status · Logs · Stop"]
+        NODES["Node Registry\nList + schema per node type"]
+        LLM_API["LLM API\nChat · Models · Test connection"]
+        MCP_API["MCP API\nTest · List tools"]
+        KB_API["Knowledge Bases API\nCRUD knowledge bases"]
+        DOCS_API["Documents API\nUpload · List · Delete"]
+        RAG_API["RAG Query API\nNatural language retrieval"]
+        MEM_API["Memory API\nGet · Append · Clear per-flow/session"]
+        WS_API["WebSocket Handler\n/ws/executions/{id}"]
+
+        RUNNER["Execution Runner\nBackground task · LangGraph invoke\nExecutionLog persistence"]
+        COMPILER["Flow Compiler\nFlow JSON → LangGraph StateGraph"]
+        GRAPH["Graph Utilities\nTopological sort · Cycle detection\nInput resolution"]
+        EXECUTORS["Node Executors\nOne executor per node type"]
+        CONNECTORS["LLM Connectors\nAzure OpenAI · Bedrock\nVertex AI · Ollama"]
+        CONN_MGR["ConnectionManager\nasyncio.Queue fan-out per execution_id"]
+        RAG_SVC["RAG Service\nChunk · Embed · Retrieve"]
+        INGEST["Document Ingestion\nBackground chunking + embedding"]
+
+        DB["SQLAlchemy (async)\nFlows · Executions · Logs\nKnowledge Bases · Documents · Memory"]
+    end
+
+    subgraph External
+        PG[("PostgreSQL\nor SQLite")]
+        QDRANT["Qdrant\nVector Store"]
+        AZURE_OAI["Azure OpenAI"]
+        BEDROCK["AWS Bedrock"]
+        VERTEX["GCP Vertex AI"]
+        OLLAMA["Ollama\n(local LLM)"]
+        MCP_SRV["MCP Servers\n(external tools)"]
+    end
+
+    UI --> MW --> API
+    WS_CLIENT --> WS_API
+    API --> FLOWS & EXEC_API & NODES & LLM_API & MCP_API & KB_API & DOCS_API & RAG_API & MEM_API
+    EXEC_API -->|background task| RUNNER
+    RUNNER --> COMPILER --> GRAPH
+    RUNNER --> EXECUTORS
+    RUNNER --> CONN_MGR --> WS_API
+    RUNNER --> DB
+    EXECUTORS --> CONNECTORS
+    CONNECTORS --> AZURE_OAI & BEDROCK & VERTEX & OLLAMA
+    DOCS_API -->|background task| INGEST
+    INGEST --> QDRANT
+    RAG_API --> RAG_SVC --> QDRANT
+    MCP_API --> MCP_SRV
+    FLOWS & EXEC_API & KB_API & DOCS_API & MEM_API --> DB
+    DB --> PG
+```
+
+**Key subsystems:**
+- **Execution Runner** — orchestrates the full lifecycle of a flow run: compiles the graph, invokes LangGraph, persists per-node logs, broadcasts WebSocket events, and writes the final execution status.
+- **Flow Compiler** — converts a stored flow definition (nodes + edges JSON) into a `LangGraph StateGraph`. Each node type maps to an executor function. Conditional edges are wired from the graph's edge list.
+- **Graph Utilities** — provides topological sort (Kahn's algorithm) and cycle detection for validation paths. The compiler delegates ordering to LangGraph natively to support agent-loop cycles.
+- **Node Executors** — one executor per node type (LLM, tool, input, output, RAG, memory, etc.). Called by LangGraph during graph traversal.
+- **LLM Connectors** — thin async adapters wrapping each provider's SDK. A single `get_connector(provider)` factory selects the right implementation at runtime.
+- **ConnectionManager** — maintains a dictionary of `execution_id → [(WebSocket, asyncio.Queue)]`. The runner calls `broadcast()` after each node; queues fan out to all connected WebSocket clients without blocking execution.
+- **RAG Service** — embeds the query, retrieves top-k chunks from Qdrant, and assembles context for the response.
+- **Document Ingestion** — runs as a `BackgroundTask`; chunks the uploaded file, generates embeddings via the configured LLM connector, and upserts vectors into Qdrant.
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| PostgreSQL | External DB | Production relational store for flows, executions, logs, knowledge bases, documents, memory |
+| SQLite (`aiosqlite`) | Local file | Default DB for local development — same schema, no external service required |
+| Qdrant | External (HTTP/gRPC) | Vector store for document embeddings and RAG retrieval |
+| Azure OpenAI | External (HTTPS) | LLM chat and embedding via Azure-hosted OpenAI models |
+| AWS Bedrock | External (HTTPS/SDK) | LLM chat via AWS-hosted foundation models |
+| GCP Vertex AI | External (HTTPS/SDK) | LLM chat via Google Gemini models |
+| Ollama | External (HTTP, local) | Local open-source LLM inference (no cloud dependency) |
+| MCP Servers | External (HTTP/SSE) | Tool discovery and invocation via Model Context Protocol |
+| Alembic | Build-time | Database schema migrations |
+
+---
+
+## 3. Architectural Decisions
+
+### AD-ADB1 — LangGraph as the execution engine
+**Decision:** Flow execution is powered by LangGraph's `StateGraph`, not a custom graph traversal loop.
+**Reason:** LangGraph natively handles agent-loop patterns (cycles), conditional branching, and multi-step tool-calling workflows that a plain topological sort cannot represent. This makes the execution engine robust for real agentic workloads without custom control-flow code.
+
+### AD-ADB2 — Execution runs as a FastAPI BackgroundTask
+**Decision:** `POST /run` creates an execution record, enqueues the run as a `BackgroundTask`, and returns `202 Accepted` with the `execution_id` immediately.
+**Reason:** LLM calls can take seconds to minutes. Holding an HTTP connection open for that duration is unreliable and wastes server resources. The caller polls status or subscribes via WebSocket.
+
+### AD-ADB3 — In-process asyncio.Queue for WebSocket fan-out (no Redis)
+**Decision:** WebSocket event delivery uses an in-process `asyncio.Queue` per client connection, managed by a `ConnectionManager` singleton.
+**Reason:** Eliminates a Redis dependency for single-instance deployments (the primary deployment target). The runner's `broadcast()` is a simple queue `put` — no serialisation overhead for local connections. For multi-instance deployments, the architecture can be extended by replacing the in-process queues with a pub/sub backend.
+
+### AD-ADB4 — SQLite default, PostgreSQL in production, same codebase
+**Decision:** The database URL is read from `DATABASE_URL` env var. SQLite (`aiosqlite`) is used by default; PostgreSQL (`asyncpg`) is used in production. No code changes are needed to switch.
+**Reason:** Developers can run the service with zero external dependencies (`python run.py`). Production deployments use the same binary with a different env var. Alembic manages schema for both dialects.
+
+### AD-ADB5 — LLM connectors as pluggable adapters behind a factory
+**Decision:** Each LLM provider (Azure OpenAI, Bedrock, Vertex AI, Ollama) is implemented as an independent connector class. `get_connector(provider)` selects the right one at runtime.
+**Reason:** Adding or swapping a provider requires only a new connector class — no changes to the execution engine, node executors, or API layer. Provider credentials are injected from config, not hardcoded.
+
+### AD-ADB6 — Graph cycle detection separate from LangGraph compilation
+**Decision:** `graph.py` provides a standalone topological sort and cycle detector (Kahn's algorithm) used for validation and dry-run paths. The LangGraph compiler does not call it — LangGraph handles ordering natively.
+**Reason:** Validation must be fast and must not require a full LangGraph compilation. The standalone utility catches invalid DAG structures early (e.g., at flow save time) before any execution is attempted.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Flow Execution with Real-Time WebSocket Streaming
+
+```mermaid
+sequenceDiagram
+    participant UI as Designer UI
+    participant API as FastAPI
+    participant BG as Background Task
+    participant COMPILER as Flow Compiler
+    participant LG as LangGraph
+    participant EXEC as Node Executor
+    participant CM as ConnectionManager
+    participant WS as WebSocket Client
+    participant DB as Database
+
+    UI->>API: POST /api/v1/executions/flows/{id}/run {input}
+    API->>DB: INSERT execution (status=pending)
+    API-->>UI: 202 Accepted {execution_id}
+    UI->>API: WS /ws/executions/{execution_id}
+    API->>CM: connect(execution_id, websocket)
+    BG->>DB: UPDATE execution (status=running)
+    BG->>COMPILER: compile_flow(flow_definition)
+    COMPILER-->>BG: StateGraph
+    loop For each node in graph
+        BG->>LG: invoke next node
+        LG->>EXEC: execute node (LLM call / tool / RAG)
+        EXEC-->>LG: node output
+        LG-->>BG: node result
+        BG->>DB: INSERT ExecutionLog (node, output)
+        BG->>CM: broadcast(execution_id, event)
+        CM-->>WS: SSE event {node_id, status, output}
+    end
+    BG->>DB: UPDATE execution (status=completed)
+    BG->>CM: broadcast(execution_id, {done: true})
+```
+
+### Flow 2 — Document Upload and RAG Ingestion
+
+```mermaid
+sequenceDiagram
+    participant UI as Designer UI
+    participant API as FastAPI
+    participant BG as Background Task
+    participant INGEST as Ingestion Pipeline
+    participant LLM as LLM Connector (Embeddings)
+    participant QD as Qdrant
+    participant DB as Database
+
+    UI->>API: POST /api/v1/knowledge-bases/{kb_id}/documents (file upload)
+    API->>DB: INSERT document (status=processing)
+    API-->>UI: 202 Accepted {document_id}
+    BG->>INGEST: ingest_document(file, kb_id)
+    INGEST->>INGEST: Chunk document (fixed-size or semantic)
+    INGEST->>LLM: Embed chunks (batch)
+    LLM-->>INGEST: Embedding vectors
+    INGEST->>QD: Upsert vectors (collection=kb_id)
+    INGEST->>DB: UPDATE document (status=ready, chunk_count)
+```
+
+### Flow 3 — RAG Query
+
+```mermaid
+sequenceDiagram
+    participant UI as Designer UI
+    participant API as FastAPI
+    participant RAG as RAG Service
+    participant LLM as LLM Connector (Embeddings)
+    participant QD as Qdrant
+
+    UI->>API: POST /api/v1/rag/query {kb_id, query, top_k}
+    API->>RAG: query_rag(request)
+    RAG->>LLM: Embed query text
+    LLM-->>RAG: Query vector
+    RAG->>QD: Search(collection=kb_id, vector, top_k)
+    QD-->>RAG: Top-k chunks with scores
+    RAG-->>API: {chunks, sources}
+    API-->>UI: 200 OK {chunks, sources}
+```
+
+### Flow 4 — LLM Connectivity Test
+
+```mermaid
+sequenceDiagram
+    participant UI as Designer UI
+    participant API as FastAPI
+    participant FACTORY as get_connector()
+    participant CONN as LLM Connector
+    participant LLM as LLM Provider
+
+    UI->>API: POST /api/v1/llm/test {provider, model}
+    API->>FACTORY: get_connector(provider)
+    FACTORY-->>API: connector instance
+    API->>CONN: list_models() [if model not supplied]
+    CONN-->>API: [model list]
+    API->>CONN: chat(model, [{role:user, content:ping}], max_tokens=5)
+    CONN->>LLM: API call
+    LLM-->>CONN: response token
+    CONN-->>API: ok
+    API-->>UI: 200 OK {status: ok, provider}
+```

--- a/agent-designer-backend/docs/SCOPE.md
+++ b/agent-designer-backend/docs/SCOPE.md
@@ -1,0 +1,103 @@
+# Agent Designer Backend — Scope
+
+## Objective
+
+Provide the **REST and WebSocket API backend** for the AgentFlow Designer UI. The service enables users to author AI agent flows as node graphs, execute them via LangGraph, query knowledge bases through RAG pipelines, connect to multiple LLM providers, integrate external MCP tools, and manage per-flow conversation memory. It is a Python FastAPI application that operates independently of the Java backend.
+
+---
+
+## Functional Requirements
+
+### Flow Authoring
+
+| ID | Requirement |
+|---|---|
+| FR-ADB1 | Users can create, retrieve, update, and delete agent flows. Each flow stores a node graph (nodes + edges) as its definition. |
+| FR-ADB2 | Users can list all flows with pagination support (`skip`, `limit`). |
+| FR-ADB3 | The service validates flow graph structure (topological sort, cycle detection) before accepting execution requests. |
+
+### Flow Execution
+
+| ID | Requirement |
+|---|---|
+| FR-ADB4 | Users can trigger a flow execution via `POST /api/v1/executions/flows/{flow_id}/run`. The call returns immediately with an `execution_id`; execution proceeds asynchronously in a background task. |
+| FR-ADB5 | Users can list all executions, optionally filtered by `flow_id`, with pagination. |
+| FR-ADB6 | Users can retrieve the current status and details of a specific execution. |
+| FR-ADB7 | Users can retrieve structured per-node execution logs for any execution, with pagination. |
+| FR-ADB8 | Users can stop a running execution. |
+
+### Real-Time Execution Streaming
+
+| ID | Requirement |
+|---|---|
+| FR-ADB9 | Clients can connect to `WebSocket /ws/executions/{execution_id}` to receive real-time node-level events as the execution progresses. |
+| FR-ADB10 | The WebSocket connection pushes events for each node transition — including node start, completion, and output — without requiring polling. |
+
+### Node Registry
+
+| ID | Requirement |
+|---|---|
+| FR-ADB11 | The service exposes a node registry listing all supported node types with their input/output schemas. |
+| FR-ADB12 | Users can retrieve the schema for a specific node type by name. |
+
+### LLM Connectivity
+
+| ID | Requirement |
+|---|---|
+| FR-ADB13 | Users can send a chat request to any configured LLM provider via `POST /api/v1/llm/chat`, specifying provider, model, messages, temperature, and max tokens. |
+| FR-ADB14 | Users can list available models for a given provider via `GET /api/v1/llm/models`. |
+| FR-ADB15 | Users can test connectivity to an LLM provider via `POST /api/v1/llm/test`. |
+| FR-ADB16 | Supported LLM providers: Azure OpenAI, AWS Bedrock, GCP Vertex AI (Gemini), and Ollama (local). |
+
+### MCP Tool Integration
+
+| ID | Requirement |
+|---|---|
+| FR-ADB17 | Users can test connectivity to an MCP server and retrieve its available tools via `POST /api/v1/mcp/test`. |
+| FR-ADB18 | Users can list all tools exposed by an MCP server via `GET /api/v1/mcp/servers/{server_url}/tools`. |
+
+### Knowledge Bases & Documents
+
+| ID | Requirement |
+|---|---|
+| FR-ADB19 | Users can create, retrieve, update, and delete named knowledge bases. |
+| FR-ADB20 | Users can upload documents to a knowledge base. Uploaded documents are ingested asynchronously — chunked, embedded, and indexed in the vector store. |
+| FR-ADB21 | Users can list and delete documents within a knowledge base. |
+
+### RAG Query
+
+| ID | Requirement |
+|---|---|
+| FR-ADB22 | Users can query a knowledge base using natural language via `POST /api/v1/rag/query`. The service retrieves relevant document chunks from the vector store and returns them as context. |
+
+### Conversation Memory
+
+| ID | Requirement |
+|---|---|
+| FR-ADB23 | The service stores and retrieves per-flow, per-session conversation memory entries (role + content + timestamp). |
+| FR-ADB24 | Users can append new entries to a flow's memory for a given session. |
+| FR-ADB25 | Users can clear all memory for a flow, optionally scoped to a specific session. |
+
+### API Documentation
+
+| ID | Requirement |
+|---|---|
+| FR-ADB26 | The service exposes interactive API documentation at `/docs` (Swagger UI) and `/redoc`. |
+| FR-ADB27 | A health check endpoint is available at `/health`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-ADB1 | Flow execution is non-blocking. `POST /run` responds in **< 200 ms**; actual execution time depends on the LLM provider and flow complexity. |
+| NFR-ADB2 | The service is built on **Python 3.11+** with FastAPI and fully async I/O (`asyncio`, `aiosqlite`, `asyncpg`). All database and LLM calls are non-blocking. |
+| NFR-ADB3 | Document ingestion runs as a FastAPI `BackgroundTask` — the upload API call returns before ingestion completes. |
+| NFR-ADB4 | WebSocket event delivery uses an in-process `asyncio.Queue` per connection — no external message broker (Redis, Kafka) is required. |
+| NFR-ADB5 | The service supports **SQLite** (default, local development) and **PostgreSQL** (production) via a single `DATABASE_URL` environment variable. Database schema is managed with Alembic migrations. |
+| NFR-ADB6 | The vector store is **Qdrant**. Host, port, API key, and gRPC mode are configurable via environment variables. |
+| NFR-ADB7 | All sensitive credentials (LLM API keys, cloud credentials) are loaded exclusively from environment variables. They are never stored in the database or returned in API responses. |
+| NFR-ADB8 | CORS allowed origins are configurable via the `CORS_ORIGINS` environment variable (JSON array or comma-separated). |
+| NFR-ADB9 | All request paths and response times are logged via a middleware layer for observability. |
+| NFR-ADB10 | Flow graph cycle detection prevents invalid DAG execution. Cyclic patterns are supported only for agent-loop node types handled natively by LangGraph. |

--- a/docker/.env.ui-only.sample
+++ b/docker/.env.ui-only.sample
@@ -1,0 +1,31 @@
+# .env.ui-only.sample — Developer UI-only mode
+#
+# Copy this file to .env.ui-only and fill in your shared backend server details.
+#   cp .env.ui-only.sample .env.ui-only
+#
+# Then start the UI with:
+#   docker compose -f docker-compose.ui-only.yml up --build
+#
+# Access the UI at: https://localhost:8084
+
+# ── Required: Shared Backend Server ──────────────────────────────────────────
+# Host:port of the Spring Boot API gateway (no http:// prefix)
+ESSEDUM_BACKEND_UPSTREAM=<SERVER_IP>:8080
+
+# Host:port of the Keycloak container (no http:// prefix)
+ESSEDUM_KEYCLOAK_UPSTREAM=<SERVER_IP>:8180
+
+# Full browser-accessible Keycloak OIDC issuer URL
+# This must be reachable from your laptop browser (not just server-to-server)
+KEYCLOAK_ISSUER=http://<SERVER_IP>:8180/realms/ESSEDUM
+
+# ── Optional: Iframe-embedded service URLs ────────────────────────────────────
+# Leave empty if the service is not running on the shared backend
+FE_LANGFLOW_URL=https://<SERVER_IP>:8086
+FE_LANGFUSE_URL=https://<SERVER_IP>:8087
+FE_LITELLM_URL=https://<SERVER_IP>:4000/ui/
+FE_SALUS_URL=
+FE_MINIO_ENDPOINT=http://<SERVER_IP>:9000
+FE_MINIO_BUCKET=essedum
+FE_CONTAINER_REGISTRY_PREFIX=
+FE_CONTAINER_REGISTRY_VERSION=

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,8 @@
 9. [Deployment Topology (Docker Compose)](#9-deployment-topology-docker-compose)
 10. [Kubernetes / AKS Deployment](#10-kubernetes--aks-deployment)
 11. [End-to-End Request Flow](#11-end-to-end-request-flow)
+12. [Cross-Service Interaction Flows](#12-cross-service-interaction-flows)
+13. [Service Architecture Index](#service-architecture-index)
 
 ---
 
@@ -808,6 +810,260 @@ flowchart TD
 
 ---
 
+## 12. Cross-Service Interaction Flows
+
+These flows document how services collaborate to deliver the platform's key capabilities. Each service's internal steps are intentionally abbreviated here — refer to the [Service Architecture Index](#service-architecture-index) for what happens inside each service.
+
+---
+
+### Flow 1 — User Login and First Authenticated API Call
+
+Covers: Browser → Nginx → Keycloak → Gateway → USM
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant NGX as Nginx
+    participant KC as Keycloak
+    participant GW as API Gateway
+    participant USM as USM Service
+
+    B->>NGX: Navigate to app (unauthenticated)
+    NGX->>B: Serve Angular shell (index.html)
+    B->>NGX: GET /realms/ESSEDUM/.well-known/openid-configuration
+    NGX->>KC: Forward (KC proxy route)
+    KC-->>B: OIDC discovery document
+    B->>KC: PKCE auth request → login page
+    KC-->>B: Redirect with auth code
+    B->>KC: Exchange code for tokens
+    KC-->>B: access_token + refresh_token
+    Note over B: Angular stores token; all subsequent calls carry Bearer header
+    B->>NGX: GET /api/usm/users (Bearer token)
+    NGX->>GW: Forward
+    GW->>KC: Validate token (JWK Set URI — cached)
+    KC-->>GW: Token valid + claims
+    GW->>USM: Forward + user claims in headers
+    USM->>USM: Resolve permissions for user roles
+    USM-->>GW: 200 OK [users]
+    GW-->>NGX-->>B: 200 OK [users]
+```
+
+---
+
+### Flow 2 — Pipeline Execution End-to-End
+
+Covers: ICIP → Python Executor → Data Service → MinIO → ICIP (completion)
+
+```mermaid
+sequenceDiagram
+    participant UI as Browser (UI)
+    participant GW as API Gateway
+    participant ICIP as ICIP Service
+    participant EXEC as Python Executor
+    participant DATA as Data Service
+    participant MINIO as MinIO
+
+    UI->>GW: POST /api/aip/jobs/run {pipelineId, executionContainerId}
+    GW->>ICIP: Forward
+    ICIP->>ICIP: Resolve execution container (cloud target + credentials)
+    ICIP->>ICIP: Create Job record (QUEUED)
+    ICIP-->>UI: 202 Accepted {jobId}
+    Note over UI: Subscribes to WebSocket /api/aip/ws/{jobId}
+    ICIP->>EXEC: POST /execute {command, bucket, credentials, storage}
+    EXEC-->>ICIP: 200 OK {task_id}
+    EXEC->>DATA: GET /api/data/files/{inputArtifactId} (download input)
+    DATA->>MINIO: Fetch object
+    MINIO-->>DATA-->>EXEC: Input file bytes
+    EXEC->>EXEC: Run pipeline subprocess
+    EXEC->>MINIO: Upload output artifacts
+    EXEC->>ICIP: Status poll response: COMPLETED
+    ICIP->>DATA: Register output artifact (POST /api/data/files)
+    ICIP->>ICIP: Update Job record (COMPLETED)
+    ICIP->>UI: WebSocket push: {status: COMPLETED, outputArtifacts}
+```
+
+---
+
+### Flow 3 — Agent Design to Kubernetes Deployment
+
+Covers: Agent Designer Backend → Vibe Code Builder Deployer → BuildKit → Kubernetes → Proxy Service + Vibe Pod Watcher
+
+```mermaid
+sequenceDiagram
+    participant UI as Browser (UI)
+    participant ADB as Agent Designer Backend
+    participant DATA as Data Service
+    participant VCB as Vibe Code Builder Deployer
+    participant BK as BuildKit
+    participant K8S as Kubernetes API
+    participant PROXY as Proxy Service
+    participant VPW as Vibe Pod Watcher
+
+    UI->>ADB: POST /api/v1/flows/{id}/run (execute agent flow)
+    ADB->>ADB: Compile flow → LangGraph graph
+    ADB-->>UI: WebSocket: execution events
+    UI->>GW: POST /api/vibe/build-deploy {agentCode, config}
+    GW->>VCB: Socket.IO start_pipeline
+    VCB->>DATA: GET source archive from MinIO
+    DATA->>VCB: Archive bytes
+    VCB->>BK: buildctl build (Dockerfile + source)
+    BK->>VCB: Build logs (streamed)
+    VCB->>UI: pipeline_update events
+    BK->>K8S: Push image to in-cluster registry
+    VCB->>K8S: Create Deployment + Service + Secret
+    K8S-->>VCB: Resources created
+    VCB->>UI: pipeline_update {status: done}
+    Note over VPW: Detects new pod via K8s watch
+    VPW->>UI: Socket.IO pod_ready event
+    UI->>PROXY: HTTP /apps/{agent-service}/* (interact with deployed agent)
+    PROXY->>K8S: Route to agent-service.aipns.svc.cluster.local
+```
+
+---
+
+### Flow 4 — RAG Pipeline (Document Ingestion → Query)
+
+Covers: Data Service → Qdrant → ICIP → LiteLLM → LLM provider
+
+```mermaid
+sequenceDiagram
+    participant UI as Browser (UI)
+    participant GW as API Gateway
+    participant DATA as Data Service
+    participant QDRANT as Qdrant
+    participant ICIP as ICIP Service
+    participant LITELLM as LiteLLM
+    participant LLM as LLM Provider
+
+    Note over UI,LLM: Part 1 — Document Ingestion
+    UI->>GW: POST /api/data/knowledge-bases/{kb}/documents (file upload)
+    GW->>DATA: Forward
+    DATA->>DATA: Chunk document (background task)
+    DATA->>LITELLM: POST /embeddings {chunks}
+    LITELLM->>LLM: Embedding request
+    LLM-->>LITELLM: Embedding vectors
+    LITELLM-->>DATA: Vectors
+    DATA->>QDRANT: Upsert vectors (collection=kb_id)
+    DATA-->>UI: 202 Accepted
+
+    Note over UI,LLM: Part 2 — RAG Query at Pipeline Execution
+    ICIP->>ICIP: Execute RAG node in pipeline
+    ICIP->>DATA: POST /api/data/rag/query {kb_id, query, top_k}
+    DATA->>LITELLM: POST /embeddings {query_text}
+    LITELLM->>LLM: Embedding request
+    LLM-->>DATA: Query vector
+    DATA->>QDRANT: Search(collection=kb_id, vector, top_k)
+    QDRANT-->>DATA: Top-k chunks + scores
+    DATA-->>ICIP: {chunks, sources}
+    ICIP->>LITELLM: POST /chat/completions {prompt + chunks as context}
+    LITELLM->>LLM: Chat completion
+    LLM-->>LITELLM-->>ICIP: LLM response
+    ICIP-->>UI: Pipeline output with RAG-grounded answer
+```
+
+---
+
+### Flow 5 — Vibe AI Coding Session (Code Generation → GitHub Push)
+
+Covers: Vibe Service → Goose AI → Vibe Service → GitHub
+
+```mermaid
+sequenceDiagram
+    participant UI as Browser / VS Code Ext
+    participant GW as API Gateway
+    participant VIBE as Vibe Service
+    participant GOOSE as Goose AI Engine
+    participant GH as GitHub API
+
+    UI->>GW: POST /api/vibe/coding/run {sessionId, prompt}
+    GW->>VIBE: Forward
+    VIBE->>VIBE: Load session + recipe context
+    VIBE->>GOOSE: POST /run {prompt + context} (streaming)
+    GOOSE-->>VIBE: Token stream
+    VIBE-->>UI: SSE event stream (token by token)
+    GOOSE-->>VIBE: [stream complete]
+    VIBE->>VIBE: Persist full response to session history
+    VIBE-->>UI: SSE done
+
+    Note over UI,GH: User reviews code, clicks Push to GitHub
+    UI->>GW: POST /api/vibe/github/push {sessionId, repo, branch}
+    GW->>VIBE: Forward
+    VIBE->>VIBE: Fetch GitHub OAuth token from Vault
+    VIBE->>GH: PUT /repos/{owner}/{repo}/contents/{path} {content, sha?}
+    GH-->>VIBE: 201 Created {commitUrl}
+    VIBE-->>UI: 200 OK {commitUrl}
+```
+
+---
+
+### Flow 6 — LLM Call with Observability (LiteLLM → LangFuse)
+
+Covers: Any service → LiteLLM → LLM provider → LangFuse trace
+
+```mermaid
+sequenceDiagram
+    participant SVC as Platform Service\n(ICIP / Data / Agent Designer)
+    participant LITELLM as LiteLLM Proxy
+    participant LLM as LLM Provider\n(OpenAI / Bedrock / Gemini)
+    participant LF as LangFuse
+    participant CH as ClickHouse
+
+    SVC->>LITELLM: POST /chat/completions {model, messages, ...}
+    LITELLM->>LITELLM: Route to configured provider
+    LITELLM->>LLM: Provider-specific API call
+    LLM-->>LITELLM: Response tokens
+    LITELLM-->>SVC: 200 OK {choices}
+    LITELLM->>LF: Async trace event {model, tokens, latency, cost}
+    LF->>LF: Enrich trace (user, session, tags)
+    LF->>CH: Persist trace to ClickHouse (analytics)
+    Note over LF: Trace visible in LangFuse UI\n— token count, cost, latency, prompt
+```
+
+---
+
+### Flow 7 — Model Training to Endpoint Deployment
+
+Covers: ICIP → SageMaker Executor → AWS SageMaker → ICIP model registry → endpoint
+
+```mermaid
+sequenceDiagram
+    participant UI as Browser (UI)
+    participant GW as API Gateway
+    participant ICIP as ICIP Service
+    participant PYSM as SageMaker Executor
+    participant SM as AWS SageMaker
+    participant DATA as Data Service
+    participant MINIO as MinIO
+
+    UI->>GW: POST /api/aip/jobs/run {pipelineId, type: training}
+    GW->>ICIP: Forward
+    ICIP->>PYSM: POST /api/service/v1/pipelines/training/train {dataset, config}
+    PYSM->>SM: CreateTrainingJob (SDK)
+    SM-->>PYSM: Job ARN
+    PYSM-->>ICIP: {job_id}
+    loop Poll until terminal
+        PYSM->>SM: DescribeTrainingJob
+        SM-->>PYSM: Status
+        PYSM->>ICIP: Status update
+        ICIP->>UI: WebSocket push
+    end
+    SM->>MINIO: Upload trained model artifact (via S3 adapter)
+    ICIP->>PYSM: POST /api/service/v1/models/register {s3_uri, metadata}
+    PYSM->>SM: RegisterModel
+    SM-->>PYSM: Model ARN
+    ICIP->>ICIP: Register model in model registry (DB)
+    ICIP->>UI: WebSocket: {status: COMPLETED, modelId}
+    Note over UI,SM: User deploys model from UI
+    UI->>GW: POST /api/modelservice/endpoints/{id}/deploy {modelId, instanceType}
+    GW->>ICIP: Forward
+    ICIP->>PYSM: POST /api/service/v1/endpoints/{id}/deploy_model
+    PYSM->>SM: CreateEndpoint
+    SM-->>PYSM: Endpoint ARN (Creating)
+    ICIP-->>UI: 202 Accepted — endpoint deploying
+```
+
+---
+
 ## Component Port Reference
 
 | Component | Port | Technology | Purpose |
@@ -840,3 +1096,47 @@ flowchart TD
 ---
 
 *Document auto-generated from codebase analysis — 2026-07-13*
+
+---
+
+## Service Architecture Index
+
+Detailed architecture for each service — internal component diagrams, dependency maps, architectural decisions, and significant flows.
+
+### Java Backend
+
+| Service | Architecture Doc |
+|---|---|
+| Backend Overview | [sv/docs/ARCHITECTURE.md](../sv/docs/ARCHITECTURE.md) |
+| API Gateway | [sv/api-gateway/docs/ARCHITECTURE.md](../sv/api-gateway/docs/ARCHITECTURE.md) |
+| USM Service | [sv/usm-service/docs/ARCHITECTURE.md](../sv/usm-service/docs/ARCHITECTURE.md) |
+| ICIP Service | [sv/icip-service/docs/ARCHITECTURE.md](../sv/icip-service/docs/ARCHITECTURE.md) |
+| Data Service | [sv/data-service/docs/ARCHITECTURE.md](../sv/data-service/docs/ARCHITECTURE.md) · [OpenAPI Spec](../sv/data-service/docs/openapi.yaml) |
+| Vibe Service | [sv/vibe-service/docs/ARCHITECTURE.md](../sv/vibe-service/docs/ARCHITECTURE.md) |
+
+### AI / Agent Backend
+
+| Service | Architecture Doc |
+|---|---|
+| Agent Designer Backend | [agent-designer-backend/docs/ARCHITECTURE.md](../agent-designer-backend/docs/ARCHITECTURE.md) |
+
+### Python Job Executors
+
+| Service | Architecture Doc |
+|---|---|
+| General Python Executor | [py-job-executer/docs/ARCHITECTURE.md](../py-job-executer/docs/ARCHITECTURE.md) |
+| SageMaker Executor | [py-job-sagemaker-executer/docs/ARCHITECTURE.md](../py-job-sagemaker-executer/docs/ARCHITECTURE.md) |
+| Vertex AI Executor | [py-job-vertex-executer/docs/ARCHITECTURE.md](../py-job-vertex-executer/docs/ARCHITECTURE.md) |
+| Azure ML Executor | [py-job-azure-executer/docs/ARCHITECTURE.md](../py-job-azure-executer/docs/ARCHITECTURE.md) |
+
+### Infrastructure & Developer Tools
+
+| Service | Architecture Doc |
+|---|---|
+| Nginx | [nginx/docs/ARCHITECTURE.md](../nginx/docs/ARCHITECTURE.md) |
+| Proxy Service | [proxy-service/docs/ARCHITECTURE.md](../proxy-service/docs/ARCHITECTURE.md) |
+| S3Proxy | [s3proxy/docs/ARCHITECTURE.md](../s3proxy/docs/ARCHITECTURE.md) |
+| Vibe Pod Watcher | [vibe-pod-watcher/docs/ARCHITECTURE.md](../vibe-pod-watcher/docs/ARCHITECTURE.md) |
+| Vibe Code Builder Deployer | [vibe-code-builder-deployer/docs/ARCHITECTURE.md](../vibe-code-builder-deployer/docs/ARCHITECTURE.md) |
+| ADK Code Builder Deployer | [adk-code-builder-deployer/docs/ARCHITECTURE.md](../adk-code-builder-deployer/docs/ARCHITECTURE.md) |
+| VS Code Extension | [vs-extension/docs/ARCHITECTURE.md](../vs-extension/docs/ARCHITECTURE.md) |

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -13,6 +13,7 @@
 3. [Functional Requirements](#3-functional-requirements)
 4. [Non-Functional Requirements](#4-non-functional-requirements)
 5. [Out of Scope](#5-out-of-scope)
+6. [Service Documentation Index](#service-documentation-index)
 
 ---
 
@@ -267,3 +268,47 @@ The following items are explicitly **not** covered in the current version:
 
 *Document Owner: Architecture Team*  
 *Review Cycle: Per major release*
+
+---
+
+## Service Documentation Index
+
+Each service maintains its own SCOPE.md with detailed functional and non-functional requirements. These are the authoritative source for service-level requirements — this document covers platform-wide concerns only.
+
+### Java Backend
+
+| Service | Scope | Architecture |
+|---|---|---|
+| Backend Overview | [sv/docs/SCOPE.md](../sv/docs/SCOPE.md) | [sv/docs/ARCHITECTURE.md](../sv/docs/ARCHITECTURE.md) |
+| API Gateway | [api-gateway/docs/SCOPE.md](../sv/api-gateway/docs/SCOPE.md) | [api-gateway/docs/ARCHITECTURE.md](../sv/api-gateway/docs/ARCHITECTURE.md) |
+| USM Service | [usm-service/docs/SCOPE.md](../sv/usm-service/docs/SCOPE.md) | [usm-service/docs/ARCHITECTURE.md](../sv/usm-service/docs/ARCHITECTURE.md) |
+| ICIP Service | [icip-service/docs/SCOPE.md](../sv/icip-service/docs/SCOPE.md) | [icip-service/docs/ARCHITECTURE.md](../sv/icip-service/docs/ARCHITECTURE.md) |
+| Data Service | [data-service/docs/SCOPE.md](../sv/data-service/docs/SCOPE.md) | [data-service/docs/ARCHITECTURE.md](../sv/data-service/docs/ARCHITECTURE.md) |
+| Vibe Service | [vibe-service/docs/SCOPE.md](../sv/vibe-service/docs/SCOPE.md) | [vibe-service/docs/ARCHITECTURE.md](../sv/vibe-service/docs/ARCHITECTURE.md) |
+
+### AI / Agent Backend
+
+| Service | Scope | Architecture |
+|---|---|---|
+| Agent Designer Backend | [agent-designer-backend/docs/SCOPE.md](../agent-designer-backend/docs/SCOPE.md) | [agent-designer-backend/docs/ARCHITECTURE.md](../agent-designer-backend/docs/ARCHITECTURE.md) |
+
+### Python Job Executors
+
+| Service | Scope | Architecture |
+|---|---|---|
+| General Python Executor | [py-job-executer/docs/SCOPE.md](../py-job-executer/docs/SCOPE.md) | [py-job-executer/docs/ARCHITECTURE.md](../py-job-executer/docs/ARCHITECTURE.md) |
+| SageMaker Executor | [py-job-sagemaker-executer/docs/SCOPE.md](../py-job-sagemaker-executer/docs/SCOPE.md) | [py-job-sagemaker-executer/docs/ARCHITECTURE.md](../py-job-sagemaker-executer/docs/ARCHITECTURE.md) |
+| Vertex AI Executor | [py-job-vertex-executer/docs/SCOPE.md](../py-job-vertex-executer/docs/SCOPE.md) | [py-job-vertex-executer/docs/ARCHITECTURE.md](../py-job-vertex-executer/docs/ARCHITECTURE.md) |
+| Azure ML Executor | [py-job-azure-executer/docs/SCOPE.md](../py-job-azure-executer/docs/SCOPE.md) | [py-job-azure-executer/docs/ARCHITECTURE.md](../py-job-azure-executer/docs/ARCHITECTURE.md) |
+
+### Infrastructure & Developer Tools
+
+| Service | Scope | Architecture |
+|---|---|---|
+| Nginx | [nginx/docs/SCOPE.md](../nginx/docs/SCOPE.md) | [nginx/docs/ARCHITECTURE.md](../nginx/docs/ARCHITECTURE.md) |
+| Proxy Service | [proxy-service/docs/SCOPE.md](../proxy-service/docs/SCOPE.md) | [proxy-service/docs/ARCHITECTURE.md](../proxy-service/docs/ARCHITECTURE.md) |
+| S3Proxy | [s3proxy/docs/SCOPE.md](../s3proxy/docs/SCOPE.md) | [s3proxy/docs/ARCHITECTURE.md](../s3proxy/docs/ARCHITECTURE.md) |
+| Vibe Pod Watcher | [vibe-pod-watcher/docs/SCOPE.md](../vibe-pod-watcher/docs/SCOPE.md) | [vibe-pod-watcher/docs/ARCHITECTURE.md](../vibe-pod-watcher/docs/ARCHITECTURE.md) |
+| Vibe Code Builder Deployer | [vibe-code-builder-deployer/docs/SCOPE.md](../vibe-code-builder-deployer/docs/SCOPE.md) | [vibe-code-builder-deployer/docs/ARCHITECTURE.md](../vibe-code-builder-deployer/docs/ARCHITECTURE.md) |
+| ADK Code Builder Deployer | [adk-code-builder-deployer/docs/SCOPE.md](../adk-code-builder-deployer/docs/SCOPE.md) | [adk-code-builder-deployer/docs/ARCHITECTURE.md](../adk-code-builder-deployer/docs/ARCHITECTURE.md) |
+| VS Code Extension | [vs-extension/docs/SCOPE.md](../vs-extension/docs/SCOPE.md) | [vs-extension/docs/ARCHITECTURE.md](../vs-extension/docs/ARCHITECTURE.md) |

--- a/nginx/docs/ARCHITECTURE.md
+++ b/nginx/docs/ARCHITECTURE.md
@@ -1,0 +1,104 @@
+# Nginx — Architecture
+
+---
+
+## 1. Service Architecture
+
+Nginx is a **stateless reverse proxy and static file server**. It has two concerns: serve compiled Angular bundles to browsers, and forward API/WebSocket requests to upstream services. All configuration is declarative — no custom code runs inside Nginx.
+
+```mermaid
+graph LR
+    subgraph Clients
+        BROWSER["Browser"]
+    end
+
+    subgraph Nginx
+        RATE["Rate Limiter\n1000 req/s per IP"]
+        STATIC["Static File Server\nAngular dist/ bundles"]
+        PROXY["API Proxy\n/api/** → backend"]
+        WS["WebSocket Proxy\nUpgrade passthrough"]
+        TLS["TLS Termination\n(production deployments)"]
+    end
+
+    subgraph Upstream
+        BACKEND["Spring Boot Backend\n:8081–8084 / :8080 gateway"]
+    end
+
+    BROWSER -->|HTTPS| TLS --> RATE
+    RATE -->|/| STATIC
+    RATE -->|/api/**| PROXY --> BACKEND
+    RATE -->|ws://| WS --> BACKEND
+```
+
+**Key configuration variants:**
+
+| File | Purpose |
+|---|---|
+| `nginx.conf` | Local development — serves two apps on ports 8080 and 8082 |
+| `nginx_ui.conf` | Production Docker — serves shell app and AIP micro-frontend with TLS |
+| `nginx_ui_5g.conf` | 5G lab deployment variant |
+| `nginx_mfe.conf` | Micro-frontend serving configuration |
+| `nginx_shell.conf` | Shell-only serving |
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Spring Boot backend | Upstream (HTTP/WS) | Receives all `/api/**` traffic and WebSocket connections |
+| Angular `dist/` folders | Local filesystem | Source of all static files served to browsers |
+| TLS certificates | Local filesystem | Certificate + key files for HTTPS termination |
+
+Nginx has **no dependency on any database, message queue, or external service**. It is purely a proxy and file server.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-NGX1 — Single reverse proxy for all concerns
+**Decision:** TLS termination, rate limiting, CORS, request-size limits, and WebSocket upgrades are all handled at Nginx. Upstream services do not implement any of these.
+**Reason:** Centralising these cross-cutting concerns at the edge avoids duplicating security and traffic controls across multiple services, reduces attack surface, and makes policy changes (e.g., rate limit values) a single-file edit.
+
+### AD-NGX2 — SPA fallback to `index.html`
+**Decision:** All unmatched paths under the frontend location are served `index.html` rather than returning 404.
+**Reason:** Angular uses client-side routing. Direct navigation to a deep URL (e.g., `/pipelines/123`) would return 404 without this fallback, as no static file exists at that path. The fallback lets Angular's router handle the URL after the shell loads.
+
+### AD-NGX3 — Static assets cached indefinitely, HTML not cached
+**Decision:** CSS, JS, and images are served with `max` cache expiry; HTML is served with `epoch` (no-cache).
+**Reason:** Angular appends content-hash suffixes to asset filenames on each build, so cached assets are always valid. The HTML shell file (`index.html`) must never be cached — it contains the references to the current asset hashes and must always be the latest version.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Browser SPA Navigation
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant NGX as Nginx
+    participant FS as dist/ filesystem
+
+    B->>NGX: GET /pipelines/123
+    NGX->>FS: Lookup /pipelines/123 (no file)
+    NGX->>FS: Serve index.html (fallback)
+    FS-->>NGX: index.html
+    NGX-->>B: 200 index.html (no-cache)
+    Note over B: Angular router handles /pipelines/123
+```
+
+### Flow 2 — API Request Proxy
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant NGX as Nginx
+    participant BE as Backend
+
+    B->>NGX: POST /api/aip/jobs/run (Bearer token)
+    NGX->>NGX: Rate limit check (1000 req/s per IP)
+    NGX->>BE: Forward + set X-Forwarded-For, X-Real-IP, Host
+    BE-->>NGX: 202 Accepted
+    NGX-->>B: 202 Accepted
+```

--- a/nginx/docs/SCOPE.md
+++ b/nginx/docs/SCOPE.md
@@ -1,0 +1,43 @@
+# Nginx — Scope
+
+## Objective
+
+Serve as the **reverse proxy and static file server** for the Essedum platform. Nginx sits in front of the Angular frontend applications and routes API requests to the appropriate backend services. It handles TLS termination, CORS headers, rate limiting, WebSocket upgrades, and file size limits in one place so individual services do not need to manage these concerns.
+
+---
+
+## Functional Requirements
+
+### Frontend Serving
+
+| ID | Requirement |
+|---|---|
+| FR-NGX1 | Nginx serves the Angular shell application (`common-app`) and the AIP micro-frontend (`icip-app`) as static files from their respective `dist/` build output directories. |
+| FR-NGX2 | All navigation requests (SPA routes) that do not match a static file are rewritten to `index.html` so Angular's client-side router handles them. |
+| FR-NGX3 | Static assets (CSS, JavaScript, images) are served with long-lived cache headers (`max` expiry). HTML files are served with `epoch` (no-cache) to ensure the latest shell is always loaded. |
+
+### API Proxy
+
+| ID | Requirement |
+|---|---|
+| FR-NGX4 | Requests to `/api/**` are proxied to the backend Spring Boot service. The `Host`, `X-Forwarded-Proto`, `X-Real-IP`, and `X-Forwarded-For` headers are set on proxied requests. |
+| FR-NGX5 | WebSocket upgrade connections (`Upgrade: websocket`) are proxied through to the backend service using the `connection_upgrade` map. |
+| FR-NGX6 | The proxy supports request bodies up to **500 MB** to accommodate file uploads forwarded through Nginx. |
+
+### Security & Traffic Control
+
+| ID | Requirement |
+|---|---|
+| FR-NGX7 | Rate limiting is enforced per client IP using a shared zone of 10 MB (`zone=one`), capping at **1000 req/s**. |
+| FR-NGX8 | TLS termination is handled at Nginx for HTTPS deployments. Certificates and keys are provided by the deployment configuration. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-NGX1 | Nginx runs as a single worker process (`worker_processes 1`) with up to **1024 simultaneous connections** per worker. |
+| NFR-NGX2 | Keep-alive timeout is set to **60 seconds** for persistent upstream connections. |
+| NFR-NGX3 | Character encoding is forced to **UTF-8** for all served content. |
+| NFR-NGX4 | The configuration is environment-specific — directory paths, upstream addresses, and TLS settings are provided per deployment. The repo ships `nginx.conf` (dev), `nginx_ui.conf` (production Docker), and `nginx_ui_5g.conf` (5G lab) variants. |

--- a/proxy-service/docs/ARCHITECTURE.md
+++ b/proxy-service/docs/ARCHITECTURE.md
@@ -1,0 +1,109 @@
+# Proxy Service — Architecture
+
+---
+
+## 1. Service Architecture
+
+A fully async **aiohttp** application with two proxy handlers — one for HTTP/polling and one for WebSocket upgrades. Both handlers share the same service-name validation, allowlist check, subpath sanitization, and upstream URL validation before forwarding any request.
+
+```mermaid
+graph LR
+    subgraph Inbound
+        UI["Essedum UI\n(HTTP + Socket.IO WS)"]
+    end
+
+    subgraph Proxy Service
+        HEALTH["Health\nGET /health"]
+        VALIDATE["Validator\nDNS-label check · Allowlist check\nSubpath normpath · Upstream URL check"]
+        HTTP_PROXY["HTTP Proxy\nForward HTTP + strip hop-by-hop\nFilter query params"]
+        WS_PROXY["WebSocket Proxy\nBidirectional WS frame relay\nSocket.IO upgrade passthrough"]
+    end
+
+    subgraph Kubernetes Cluster
+        POD_SVC["Pod Service\n{name}.{ns}.svc.cluster.local"]
+    end
+
+    UI -->|GET /{service}/{subpath}| HTTP_PROXY
+    UI -->|WS /{service}/socket.io| WS_PROXY
+    HTTP_PROXY --> VALIDATE --> POD_SVC
+    WS_PROXY --> VALIDATE --> POD_SVC
+```
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Kubernetes cluster DNS | Internal (DNS) | Resolve `{service}.{namespace}.svc.cluster.local` to pod IP |
+| Target pod services | Internal (HTTP/WS) | Upstream endpoints for proxied requests |
+
+The service has **no database, no authentication module, and no external dependencies** beyond the Kubernetes cluster network.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-PROXY1 — DNS-label validation as the primary SSRF defence
+**Decision:** Service names from the URL path are validated against a strict DNS-label regex (`^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`) before any upstream URL is constructed.
+**Reason:** Without this, a caller could supply a service name like `../other-namespace/secret-service` or embed a full hostname to redirect the proxy to an arbitrary network target (SSRF). The DNS-label pattern guarantees only valid Kubernetes service names pass through.
+
+### AD-PROXY2 — Upstream URL validated to remain within the cluster namespace
+**Decision:** After the upstream URL is constructed, its host is checked to confirm it ends with `.{namespace}.svc.cluster.local` and uses the `http` scheme.
+**Reason:** Defense-in-depth after the name validation. Even if an attacker bypasses the DNS-label check, the URL validation ensures the request cannot escape to an external host or use an unexpected scheme.
+
+### AD-PROXY3 — Query parameters filtered to known Socket.IO set
+**Decision:** Only `EIO`, `transport`, `t`, `sid`, `j` query parameters are forwarded to upstream services.
+**Reason:** Arbitrary query parameters from user input could be used to inject unexpected arguments into the upstream service URL, potentially influencing its behaviour (query-string injection). Restricting to the known Socket.IO set closes this vector.
+
+### AD-PROXY4 — Hop-by-hop headers stripped on both request and response
+**Decision:** Standard hop-by-hop headers (`connection`, `keep-alive`, `transfer-encoding`, `upgrade`, `te`, `trailers`, `proxy-authenticate`, `proxy-authorization`) are removed before forwarding in either direction.
+**Reason:** Hop-by-hop headers are connection-scoped and must not be forwarded by proxies (RFC 7230). Forwarding them can cause connection management bugs or expose internal proxy state to clients or upstreams.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — HTTP Proxy Request
+
+```mermaid
+sequenceDiagram
+    participant UI as UI
+    participant PROXY as Proxy Service
+    participant K8S_DNS as Cluster DNS
+    participant POD as Pod Service
+
+    UI->>PROXY: GET /runner-service/api/status?EIO=4&transport=polling
+    PROXY->>PROXY: Validate "runner-service" as DNS label
+    PROXY->>PROXY: Check allowlist (if configured)
+    PROXY->>PROXY: normpath subpath "api/status"
+    PROXY->>PROXY: Build upstream: http://runner-service.aipns.svc.cluster.local/api/status
+    PROXY->>PROXY: Validate upstream host ends with .aipns.svc.cluster.local
+    PROXY->>PROXY: Filter query → {EIO:4, transport:polling}
+    PROXY->>PROXY: Strip hop-by-hop headers
+    PROXY->>K8S_DNS: Resolve runner-service.aipns.svc.cluster.local
+    PROXY->>POD: GET /api/status?EIO=4&transport=polling
+    POD-->>PROXY: 200 OK
+    PROXY-->>UI: 200 OK (hop-by-hop stripped from response)
+```
+
+### Flow 2 — WebSocket Proxy
+
+```mermaid
+sequenceDiagram
+    participant UI as UI (Socket.IO)
+    participant PROXY as Proxy Service
+    participant POD as Pod Service
+
+    UI->>PROXY: WS /runner-service/socket.io?EIO=4&transport=websocket
+    PROXY->>PROXY: Validate service name + allowlist
+    PROXY->>PROXY: Sanitize subpath → "socket.io"
+    PROXY->>PROXY: Filter WS query params
+    PROXY->>POD: WS upgrade http://runner-service.aipns.svc.cluster.local/socket.io
+    loop Bidirectional frame relay
+        UI-->>PROXY: WS frame
+        PROXY-->>POD: WS frame
+        POD-->>PROXY: WS frame
+        PROXY-->>UI: WS frame
+    end
+```

--- a/proxy-service/docs/SCOPE.md
+++ b/proxy-service/docs/SCOPE.md
@@ -1,0 +1,33 @@
+# Proxy Service — Scope
+
+## Objective
+
+Act as a **secure HTTP and WebSocket reverse proxy** between the Essedum frontend and dynamically spawned Kubernetes pod services (Vibe coding sessions, agent runners). The service routes requests to Kubernetes cluster-internal services by name, enforcing a strict allowlist and multiple layers of URL/header sanitization to prevent SSRF and injection attacks.
+
+---
+
+## Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| FR-PROXY1 | The service proxies HTTP requests from `/{service}/{subpath}` to the corresponding Kubernetes cluster-internal service at `http://{service}.{namespace}.svc.cluster.local/{subpath}`. |
+| FR-PROXY2 | The service proxies WebSocket upgrade requests for Socket.IO connections, preserving the Socket.IO transport handshake across the proxy boundary. |
+| FR-PROXY3 | Service names are validated against a strict DNS-label pattern (1–63 chars, lowercase letters, digits, hyphens, starting and ending with alphanumeric) before any upstream connection is made. Invalid names return HTTP 400. |
+| FR-PROXY4 | When an `ALLOWLIST` environment variable is set, only services explicitly listed are reachable. Requests to unlisted services return HTTP 403. |
+| FR-PROXY5 | The upstream URL is validated to confirm it resolves within `*.{namespace}.svc.cluster.local` before the connection is forwarded, preventing requests from escaping the cluster namespace. |
+| FR-PROXY6 | Only known Socket.IO query parameters (`EIO`, `transport`, `t`, `sid`, `j`) are forwarded to upstream services. All other query parameters are stripped. |
+| FR-PROXY7 | Hop-by-hop HTTP headers (`connection`, `keep-alive`, `transfer-encoding`, `upgrade`, etc.) are stripped from forwarded requests and responses. |
+| FR-PROXY8 | Subpaths are normalized using `posixpath.normpath` to remove `..` and `.` segments before being appended to the upstream URL. |
+| FR-PROXY9 | A health check endpoint is available at `/health`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-PROXY1 | The service is built on **aiohttp** with fully async I/O — no threads block on upstream HTTP or WebSocket connections. |
+| NFR-PROXY2 | The target namespace is configurable via the `TARGET_NAMESPACE` environment variable (default: `aipns`). |
+| NFR-PROXY3 | The upstream allowlist is configurable via the `ALLOWLIST` environment variable (comma-separated service names). When not set, all DNS-label-valid service names are reachable within the namespace. |
+| NFR-PROXY4 | Upstream HTTP connections use a 120-second total timeout to prevent hanging connections. |
+| NFR-PROXY5 | The service performs no authentication. It relies on the Kubernetes network policy and the upstream service itself to enforce access control. |

--- a/py-job-azure-executer/docs/ARCHITECTURE.md
+++ b/py-job-azure-executer/docs/ARCHITECTURE.md
@@ -1,0 +1,195 @@
+# Azure Job Executor — Architecture
+
+---
+
+## 1. Service Architecture
+
+The service is a **Flask HTTP microservice** that decouples job acceptance from job execution. Incoming requests are validated and queued immediately; a background thread pool consumes the queue and drives execution against Azure ML. All job state is persisted locally in SQLite so the API can answer status queries at any time, independent of execution progress.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        ICIP["ICIP Service\n(Backend)"]
+    end
+
+    subgraph Azure Job Executor
+        API["Flask REST API\n/execute · /execute/{id}/getStatus\n/execute/{id}/stop · /execute/{id}/getLog"]
+        VALIDATOR["Input Validator\nField presence · type · UUID format\nPath traversal guard"]
+        QUEUE["In-Memory Queue\nQueue.py"]
+        THREAD_POOL["ThreadPoolExecutor\nConfigurable pool size"]
+        TASK["Task Runner\nTask.py — spawns subprocess"]
+        DB["SQLite\n/data/app.db (WAL mode)\nJob state persistence"]
+        AZURE_MLOPS["Azure MLOps Adapter\nmlops/azure.py"]
+        DS["Datasource Connector\ndatasource.py · db.py\nMySQL / PostgreSQL"]
+        SWAGGER["Swagger UI\n/swagger · /swagger.json"]
+    end
+
+    subgraph External
+        AZURE_ML["Azure ML\nWorkspace · Experiments\nAutoML · Batch Endpoints"]
+        AZURE_AD["Azure AD\nOAuth2 token endpoint"]
+        EXT_DB["External Databases\nMySQL · PostgreSQL"]
+    end
+
+    ICIP -->|POST /execute| API
+    ICIP -->|GET /execute/{id}/getStatus| API
+    ICIP -->|GET /execute/{id}/stop| API
+    API --> VALIDATOR --> QUEUE
+    API --> DB
+    QUEUE --> THREAD_POOL --> TASK
+    TASK --> DB
+    TASK --> AZURE_MLOPS
+    TASK --> DS
+    AZURE_MLOPS --> AZURE_AD
+    AZURE_MLOPS --> AZURE_ML
+    DS --> EXT_DB
+    API --> SWAGGER
+```
+
+**Component responsibilities:**
+
+- **Flask REST API** — accepts and validates HTTP requests, returns immediate responses. Contains no business logic.
+- **Input Validator** — checks all required fields, types, and lengths before any job is created. UUIDs are re-validated on every `/{id}/*` endpoint. Path traversal is checked before any filesystem read.
+- **In-Memory Queue** — decouples the HTTP response from execution. Jobs are enqueued synchronously; the API returns `task_id` before execution begins.
+- **ThreadPoolExecutor** — consumes the queue concurrently. Pool size is set via `conf/conf.ini` (`ThreadCount`).
+- **Task Runner** — spawns the pipeline command as a subprocess, streams output to a log file under `/temp/Jobs/{task_id}/`, and reports return code back to the executor.
+- **SQLite (WAL mode)** — tracks all job state transitions (SUBMITTED → RUNNING → COMPLETED / ERROR / CANCELLED) with timestamps and PIDs. Thread-local connections prevent cross-thread SQLite conflicts.
+- **Azure MLOps Adapter** — all Azure ML SDK calls are isolated here. Handles token generation, dataset management, AutoML experiment submission, model registration, and batch endpoint deployment.
+- **Datasource Connector** — connects to MySQL or PostgreSQL using credentials from the job payload for pipeline input data.
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Azure ML (`azureml-core`, `azure-ai-ml`) | External (HTTP/SDK) | Submit training experiments, manage datasets and models, deploy batch endpoints |
+| Azure AD | External (HTTPS) | OAuth2 client-credentials token exchange for Azure ML API authentication |
+| SQLite (`/data/app.db`) | Local file | Job state persistence — status, timestamps, PID, log path |
+| MySQL (external, per-job) | External (TCP) | Pipeline input data, sourced from job payload credentials |
+| PostgreSQL (external, per-job) | External (TCP) | Pipeline input data, sourced from job payload credentials |
+| `conf/conf.ini` | Local file | Thread pool size, working directory, proxy settings, DB connection references |
+| Local filesystem (`/temp/Jobs/`) | Local file | Per-job execution log files |
+| `flask-swagger-ui` | Library | Swagger UI at `/swagger` |
+
+The service has **no dependency on any other Essedum microservice** at runtime. It is invoked exclusively by the ICIP Service and communicates only with Azure and optionally with user-configured external databases.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-AZ1 — In-memory queue with ThreadPoolExecutor for async job execution
+**Decision:** Job submissions are enqueued in-process and executed by a `ThreadPoolExecutor`. The submission HTTP call returns before execution starts.
+**Reason:** Azure ML jobs can run for minutes to hours. Blocking an HTTP connection for that duration is unreliable. The queue decouples API latency from execution time and allows the thread pool size to be tuned independently.
+
+### AD-AZ2 — SQLite with WAL mode as the local job store
+**Decision:** Job state is persisted in a local SQLite file at `/data/app.db` with WAL journal mode and thread-local connections.
+**Reason:** No external database dependency is required for the executor to function. WAL mode allows concurrent reads from the API thread while write operations proceed from worker threads, preventing lock contention.
+
+### AD-AZ3 — Azure MLOps logic isolated in `mlops/azure.py`
+**Decision:** All Azure SDK calls (authentication, experiment submission, model registration, endpoint deployment) are encapsulated in a single module.
+**Reason:** This keeps `app.py` focused on HTTP concerns and makes Azure ML interactions testable and replaceable without touching the API or queue logic.
+
+### AD-AZ4 — Proxy environment variables cleared before importing `requests`
+**Decision:** All proxy environment variables (`http_proxy`, `https_proxy`, etc.) are explicitly removed from `os.environ` before the `requests` module is imported.
+**Reason:** Azure ML endpoints must be reached directly. Corporate proxy settings, if present in the container environment, would block Azure SDK HTTP calls. Clearing proxies at import time ensures they are never honoured by the Azure SDK.
+
+### AD-AZ5 — HTML escaping applied to all response values
+**Decision:** A `_sanitize_for_response()` function recursively HTML-escapes all string values before they are serialised into JSON responses.
+**Reason:** The service echoes back user-submitted values (job names, commands, paths) in status and error responses. Without escaping, these create reflected XSS vectors when responses are rendered in a browser context.
+
+### AD-AZ6 — Process tree kill for job cancellation
+**Decision:** When stopping a running job, the service kills the entire OS process tree (parent + all children) using `psutil`.
+**Reason:** A pipeline subprocess may spawn child processes (Python interpreters, shell commands). Killing only the parent process would leave orphaned children consuming resources.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Job Submission and Async Execution
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Flask API
+    participant Q as In-Memory Queue
+    participant POOL as ThreadPoolExecutor
+    participant TASK as Task Runner
+    participant DB as SQLite
+    participant AZ as Azure ML
+
+    ICIP->>API: POST /execute {bucket, name, command, credentials, ...}
+    API->>API: Validate all fields (types, lengths, required keys)
+    API->>DB: INSERT job (status=SUBMITTED)
+    API->>Q: Enqueue task
+    API-->>ICIP: 201 Created {task_id, status="Submitted"}
+    Q->>POOL: Worker picks up task
+    POOL->>DB: UPDATE status=RUNNING, started=now
+    POOL->>TASK: execute_script()
+    TASK->>AZ: Submit AutoML / Script experiment
+    AZ-->>TASK: Job running (async poll)
+    TASK-->>POOL: return_code=0
+    POOL->>DB: UPDATE status=COMPLETED, finished=now, pid=PID
+```
+
+### Flow 2 — Job Status Query
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Flask API
+    participant DB as SQLite
+
+    ICIP->>API: GET /execute/{task_id}/getStatus
+    API->>API: Validate task_id is well-formed UUID
+    API->>DB: SELECT job WHERE id=task_id
+    alt Job not found
+        API-->>ICIP: 404 Not Found
+    else Job found
+        API-->>ICIP: 200 OK {task_id, task_status, submitted, started, finished, pid}
+    end
+```
+
+### Flow 3 — Job Cancellation
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Flask API
+    participant DB as SQLite
+    participant OS as OS Process
+
+    ICIP->>API: GET /execute/{task_id}/stop
+    API->>DB: SELECT job (status, pid)
+    alt status=RUNNING, pid known
+        API->>OS: psutil — kill process tree (parent + children)
+        API->>DB: Poll until status != RUNNING
+        API->>DB: UPDATE status=CANCELLED
+    else status=WAITING, future exists
+        API->>API: future.cancel()
+        API->>DB: UPDATE status=CANCELLED
+    end
+    API-->>ICIP: 200 OK {Task cancelled: true/false}
+```
+
+### Flow 4 — Azure Token Generation and ML Submission
+
+```mermaid
+sequenceDiagram
+    participant TASK as Task Runner
+    participant MLOPS as mlops/azure.py
+    participant AAD as Azure AD
+    participant AML as Azure ML Workspace
+
+    TASK->>MLOPS: submit_training_job(configs)
+    MLOPS->>MLOPS: Clear proxy env vars
+    MLOPS->>AAD: POST /oauth2/token (client_credentials grant)
+    AAD-->>MLOPS: access_token
+    MLOPS->>AML: Authenticate (ServicePrincipalAuthentication)
+    MLOPS->>AML: Create/resolve Dataset
+    MLOPS->>AML: Submit Experiment (AutoML or ScriptRunConfig)
+    AML-->>MLOPS: Run object / Job ID
+    MLOPS->>AML: Poll run status
+    AML-->>MLOPS: Completed
+    MLOPS->>AML: Register model
+    MLOPS-->>TASK: result (return_code, artifacts)
+```

--- a/py-job-azure-executer/docs/SCOPE.md
+++ b/py-job-azure-executer/docs/SCOPE.md
@@ -1,0 +1,61 @@
+# Azure Job Executor — Scope
+
+## Objective
+
+Execute AI/ML pipeline jobs on **Microsoft Azure ML** on behalf of the Essedum platform. The service receives job submissions from the ICIP backend, queues them internally, runs them against Azure ML (AutoML training, inference, model deployment), and tracks their state in a local SQLite database. It is a stateless-by-design HTTP microservice — one instance per Azure execution container.
+
+---
+
+## Functional Requirements
+
+### Job Submission
+
+| ID | Requirement |
+|---|---|
+| FR-AZ1 | The service accepts a job submission via `POST /execute` with a JSON payload containing bucket, project ID, pipeline name, version, credentials, input artifacts, command, storage type, and optional configs and environment variables. |
+| FR-AZ2 | Each submitted job is assigned a UUID and persisted in the local job store with status `SUBMITTED` before being queued. |
+| FR-AZ3 | The service validates all required fields on submission. Missing or malformed fields return HTTP 400 or 422 before the job is queued. |
+| FR-AZ4 | Submitted jobs are placed on an internal in-memory queue and processed asynchronously by a thread pool. The submission API call returns immediately with the assigned `task_id`. |
+
+### Job Lifecycle Management
+
+| ID | Requirement |
+|---|---|
+| FR-AZ5 | The caller can query the status of a job via `GET /execute/{task_id}/getStatus`, which returns the job's current state (SUBMITTED, RUNNING, COMPLETED, ERROR, CANCELLED), timestamps, and process ID. |
+| FR-AZ6 | A running or queued job can be cancelled via `GET /execute/{task_id}/stop`. Running jobs are terminated by killing the OS process tree; queued jobs are cancelled via the future. The final status is set to CANCELLED. |
+| FR-AZ7 | The service exposes `GET /execute/{task_id}/getLog` to retrieve the execution log for a specific job from the local filesystem. |
+| FR-AZ8 | The service exposes `GET /execute/getLog` to retrieve the main service log. |
+| FR-AZ9 | The service exposes `GET /execute/jobs` which renders an HTML view of the last 100 jobs and their statuses. |
+
+### Azure ML Integration
+
+| ID | Requirement |
+|---|---|
+| FR-AZ10 | The service authenticates to Azure using Service Principal credentials (`tenant_id`, `service_principal_id`, `service_principal_password`, `subscription_id`) loaded from environment variables. |
+| FR-AZ11 | The service submits training pipelines to Azure ML, including AutoML training jobs and Python script–based experiments. |
+| FR-AZ12 | The service creates and manages Azure ML datasets and registers trained models in the Azure ML model registry. |
+| FR-AZ13 | The service deploys registered models as Azure ML batch endpoints and manages batch deployments. |
+| FR-AZ14 | The service generates and caches Azure AD access tokens for Azure ML API calls via the OAuth2 client-credentials flow. |
+| FR-AZ15 | The service supports connecting to external MySQL and PostgreSQL datasources using credentials supplied in the job payload, for use as pipeline inputs. |
+
+### API Documentation
+
+| ID | Requirement |
+|---|---|
+| FR-AZ16 | The service exposes a Swagger UI at `/swagger` and serves the OpenAPI spec at `/swagger.json`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-AZ1 | Job submission (`POST /execute`) must respond in **< 200 ms**. Actual execution time is determined by the Azure ML platform. |
+| NFR-AZ2 | The thread pool size is configurable via `conf/conf.ini` (`ThreadCount`). Concurrent job execution is bounded by this setting. |
+| NFR-AZ3 | Job state is persisted in a local SQLite database at `/data/app.db` using WAL mode for concurrent read safety. Job state survives application restarts within the same pod/container. |
+| NFR-AZ4 | All string values in API responses are HTML-escaped to prevent reflected XSS. Stack traces are stripped from log output before it is returned to callers. |
+| NFR-AZ5 | Security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block`) are applied to all responses. |
+| NFR-AZ6 | Task IDs are validated as well-formed UUIDs before any filesystem or database lookup. Path traversal attacks on log file access are detected and rejected with HTTP 403. |
+| NFR-AZ7 | Azure credentials (tenant ID, service principal, subscription ID) are never returned in API responses. They are loaded exclusively from environment variables at runtime. |
+| NFR-AZ8 | All Azure HTTP calls bypass any configured proxy (`http_proxy`, `https_proxy` env vars are cleared before the `requests` module is imported) to ensure direct connectivity to Azure endpoints. |
+| NFR-AZ9 | The service runs as a Python 3.12+ Flask application. Port is configurable via environment; default configuration is specified in `conf/conf.ini`. |

--- a/py-job-executer/docs/ARCHITECTURE.md
+++ b/py-job-executer/docs/ARCHITECTURE.md
@@ -1,0 +1,194 @@
+# Python Job Executor — Architecture
+
+---
+
+## 1. Service Architecture
+
+The service is a **Flask HTTP microservice** with an asynchronous job execution engine. Submitted jobs are validated, persisted, and queued immediately — the HTTP call returns before execution begins. A background thread pool consumes the queue, spawns subprocesses for each pipeline script, and writes results back to SQLite. The service additionally exposes function-adapter execution (dynamic script generation + pip install) and virtual environment management.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        ICIP["ICIP Service\n(Backend)"]
+    end
+
+    subgraph Python Job Executor
+        API["Flask REST API\n/execute · /execute/{id}/getStatus · /execute/{id}/stop\n/execute/{id}/getLog · /execute/{id}/getOutputArtifacts\n/api/service/v1/function/execute · /venvs"]
+        VALIDATOR["Input Validator\nField presence · type · UUID format\nPath traversal guard · Package name regex"]
+        QUEUE["In-Memory Queue\nQueue.py — FIFO"]
+        THREAD_POOL["ThreadPoolExecutor\nConfigurable pool size (conf.ini)"]
+        TASK_RUNNER["Task Runner\nTask.py — downloads artifacts,\nspawns subprocess, uploads outputs"]
+        DB["SQLite\n/data/app.db (WAL mode)\nJob state persistence"]
+        FUNC_ADAPTER["Function Adapter\nfunctionadapter.py\nDynamic script gen + pip install"]
+        TASK_RETRIEVER["Task Retriever\n(optional module)\nPropagates status to external DB"]
+        SWAGGER["Swagger UI\n/swagger · /swagger.json"]
+    end
+
+    subgraph Storage
+        LOCAL["Local Filesystem\nWorking directory (conf.ini)"]
+        MINIO["MinIO\nObject storage"]
+        S3["AWS S3"]
+    end
+
+    ICIP -->|POST /execute| API
+    ICIP -->|GET /execute/{id}/getStatus| API
+    ICIP -->|GET /execute/{id}/stop| API
+    ICIP -->|POST /api/service/v1/function/execute| API
+    API --> VALIDATOR --> QUEUE
+    API --> DB
+    QUEUE --> THREAD_POOL --> TASK_RUNNER
+    TASK_RUNNER --> DB
+    TASK_RUNNER --> LOCAL
+    TASK_RUNNER --> MINIO
+    TASK_RUNNER --> S3
+    TASK_RUNNER -.->|if enabled| TASK_RETRIEVER
+    FUNC_ADAPTER --> LOCAL
+    API --> FUNC_ADAPTER
+    API --> SWAGGER
+```
+
+**Component responsibilities:**
+
+- **Flask REST API** — validates and routes HTTP requests; no business logic.
+- **Input Validator** — enforces required fields, types, and exact parameter sets. UUIDs are re-validated on every `/{id}/*` endpoint. Filesystem paths are resolved and checked against the working directory before any read or write. Package names are checked by regex before being passed to pip.
+- **In-Memory Queue** — FIFO queue backing the standard submission path. The direct-executor path bypasses the queue and submits directly to the thread pool (used for task-retriever-aware execution).
+- **ThreadPoolExecutor** — bounded concurrency. Pool size set via `conf/conf.ini` (`ThreadCount`). Processes queue tasks and direct submissions in parallel.
+- **Task Runner (`Task.py`)** — downloads input artifacts from the storage backend (local/MinIO/S3), spawns the pipeline command as an OS subprocess, streams output to a log file, uploads output artifacts on completion, and reports the return code.
+- **SQLite (WAL mode)** — tracks all job state transitions with timestamps and PIDs. Thread-local connections prevent cross-thread SQLite conflicts.
+- **Function Adapter (`functionadapter.py`)** — assembles a Python script from a structured request (imports, requirements, execution steps), installs any missing packages via pip, and executes the assembled script.
+- **Task Retriever** — optional pluggable module (selected via `conf.ini`). When enabled, the runner asynchronously writes job status updates to an external database alongside the local SQLite updates.
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| SQLite (`/data/app.db`) | Local file | Job state persistence — status, timestamps, PID, log path |
+| Local filesystem | Local | Pipeline script execution, log files, output artifacts for `storage=local` jobs |
+| MinIO | External (HTTP) | Input artifact download and output artifact upload for `storage=minio` jobs |
+| AWS S3 | External (HTTPS/SDK) | Input artifact download and output artifact upload for `storage=s3` jobs |
+| `conf/conf.ini` | Local file | Thread pool size, working directory, task-retriever config |
+| `flask-swagger-ui` | Library | Swagger UI at `/swagger` |
+| Task Retriever module | Internal (optional) | Async status propagation to an external database |
+
+The service has **no dependency on any other Essedum microservice** at runtime. It is invoked exclusively by the ICIP Service.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-PY1 — Two dispatch modes: queue and direct executor
+**Decision:** The service supports both FIFO queue dispatch (standard path) and direct thread-pool submission (bypassing the queue), selectable per-call.
+**Reason:** The FIFO queue enforces ordering and backpressure for standard pipeline jobs. The direct path is used when the task-retriever module is active and needs to correlate a specific external database entry with the execution — it avoids the ordering delay of the queue for those calls.
+
+### AD-PY2 — SQLite with WAL mode and thread-local connections
+**Decision:** Job state is persisted in a local SQLite file using WAL journal mode with thread-local database connections.
+**Reason:** No external database dependency is needed. WAL mode allows concurrent reads from the API thread while worker threads write, preventing lock contention. Thread-local connections avoid cross-thread SQLite handle sharing, which would cause runtime errors under concurrent load.
+
+### AD-PY3 — Process tree kill for job cancellation
+**Decision:** When stopping a running job, the service kills the entire OS process tree (parent + all child processes) using `psutil`.
+**Reason:** Pipeline scripts may spawn child processes (Python interpreters, shell commands, subprocesses). Killing only the parent leaves orphaned children consuming CPU and memory.
+
+### AD-PY4 — Path traversal prevention via resolved-path prefix check
+**Decision:** Every filesystem path derived from a user-supplied `task_id` or `venv` name is resolved with `os.path.realpath()` and checked to confirm it starts with the expected base directory path.
+**Reason:** Without this check, a crafted `task_id` containing `../` sequences could escape the working directory and allow arbitrary file reads or writes. The resolved-path prefix check is the standard defense against this class of attack.
+
+### AD-PY5 — Package name validation via regex before pip install
+**Decision:** In the function adapter, every package name from the request payload is validated against `^[A-Za-z0-9_\-\.]+([><=!~]{1,2}[A-Za-z0-9_\-\.]+)?$` before being passed to `pip install`.
+**Reason:** Without validation, a malicious package name could inject arbitrary shell arguments into the pip subprocess. The regex restricts names to valid PyPI package formats, preventing command injection.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Standard Job Submission and Async Execution
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Flask API
+    participant Q as In-Memory Queue
+    participant POOL as ThreadPoolExecutor
+    participant TASK as Task Runner
+    participant STORE as Storage (local/MinIO/S3)
+    participant DB as SQLite
+
+    ICIP->>API: POST /execute {bucket, name, command, credentials, storage, ...}
+    API->>API: Validate fields (types, lengths, required keys, credential shape)
+    API->>DB: INSERT job (status=SUBMITTED)
+    API->>Q: Enqueue task
+    API-->>ICIP: 200 OK {task_id, status="Submitted", log_path}
+    Q->>POOL: Worker picks up task
+    POOL->>DB: UPDATE status=RUNNING, started=now
+    POOL->>STORE: Download input artifacts
+    POOL->>TASK: Spawn subprocess (command)
+    TASK-->>POOL: return_code=0
+    POOL->>STORE: Upload output artifacts
+    POOL->>DB: UPDATE status=COMPLETED, finished=now, pid=PID
+```
+
+### Flow 2 — Job Status Query
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Flask API
+    participant DB as SQLite
+
+    ICIP->>API: GET /execute/{task_id}/getStatus
+    API->>API: Validate task_id is well-formed UUID
+    API->>DB: SELECT job WHERE id=task_id
+    alt Job not found
+        API-->>ICIP: 404 Not Found
+    else Terminal state (COMPLETED/ERROR/CANCELLED)
+        API-->>ICIP: 200 OK {task_id, status, submitted, started, finished, timestamp(elapsed), output_dir}
+    else Non-terminal state
+        API-->>ICIP: 200 OK {task_id, status, submitted, started, finished=null, timestamp=null}
+    end
+```
+
+### Flow 3 — Function Adapter Execution
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Flask API
+    participant FA as Function Adapter
+    participant PIP as pip
+    participant SCRIPT as Assembled Script
+
+    ICIP->>API: POST /api/service/v1/function/execute {Imports, Requirements, executionOrder}
+    API->>FA: function_execute(request_body)
+    FA->>FA: Validate package names via regex
+    loop For each requirement
+        FA->>PIP: pip install <package> (subprocess, no shell)
+    end
+    FA->>FA: Assemble Python script from imports + execution order
+    FA->>SCRIPT: Execute assembled script (subprocess)
+    SCRIPT-->>FA: return_code, output
+    FA-->>API: result dict
+    API-->>ICIP: 200 OK {result}
+```
+
+### Flow 4 — Job Cancellation
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Flask API
+    participant DB as SQLite
+    participant OS as OS Process Tree
+
+    ICIP->>API: GET /execute/{task_id}/stop
+    API->>DB: SELECT job (status, pid)
+    alt status=RUNNING, pid known
+        API->>OS: psutil — kill process tree (parent + all children)
+        API->>DB: Poll until status leaves RUNNING
+        API->>DB: UPDATE status=CANCELLED
+    else status=WAITING, future pending
+        API->>API: future.cancel()
+        API->>DB: UPDATE status=CANCELLED
+    end
+    API-->>ICIP: 200 OK {Task cancelled: true/false}
+```

--- a/py-job-executer/docs/SCOPE.md
+++ b/py-job-executer/docs/SCOPE.md
@@ -1,0 +1,80 @@
+# Python Job Executor — Scope
+
+## Objective
+
+Execute general-purpose Python-based AI/ML pipeline jobs on behalf of the Essedum platform. The service accepts job submissions from the ICIP backend, queues them internally, runs each job as an OS subprocess, and tracks their state in a local SQLite database. Unlike the cloud-specific executors, this service targets **local and S3/MinIO-backed** workloads and additionally provides function-adapter execution and virtual environment lifecycle management.
+
+---
+
+## Functional Requirements
+
+### Job Submission
+
+| ID | Requirement |
+|---|---|
+| FR-PY1 | The service accepts a job submission via `POST /execute` with a JSON payload containing bucket, project ID, pipeline name, version, credentials, input artifacts, command, storage type, and optional environment variables. |
+| FR-PY2 | Each submitted job is assigned a UUID and persisted in the local job store with status `SUBMITTED` before being queued. |
+| FR-PY3 | The service validates all required fields on submission. Missing or mismatched parameters return HTTP 400; type or length violations return HTTP 422. |
+| FR-PY4 | Submitted jobs are placed on an in-memory queue and processed asynchronously by a thread pool. The submission call returns immediately with the `task_id`. |
+| FR-PY5 | The service supports two dispatch modes: **queue mode** (FIFO via in-memory queue) and **direct executor mode** (immediate submission to the thread pool bypassing the queue), selected per-call by the internal `push_in_queue` flag. |
+
+### Job Lifecycle Management
+
+| ID | Requirement |
+|---|---|
+| FR-PY6 | The caller can query the status of a job via `GET /execute/{task_id}/getStatus`, which returns status (SUBMITTED, RUNNING, COMPLETED, ERROR, CANCELLED), timestamps, PID, log path, output directory, and elapsed duration for terminal states. |
+| FR-PY7 | A running or queued job can be cancelled via `GET /execute/{task_id}/stop`. Running jobs are terminated by killing the full OS process tree (parent + children) using `psutil`; queued jobs are cancelled via the future. Final status is set to CANCELLED. |
+| FR-PY8 | The service exposes `GET /execute/{task_id}/getLog` to retrieve the execution log for a specific job from the local working directory. |
+| FR-PY9 | The service exposes `GET /execute/{task_id}/getOutputArtifacts` to retrieve all output artifact files produced by a job's execution. |
+| FR-PY10 | The service exposes `GET /execute/getLog` to retrieve the main service log. |
+| FR-PY11 | The service exposes `GET /execute/jobs` which renders an HTML dashboard of the last 100 jobs and their statuses. |
+| FR-PY12 | The service exposes `GET /execute` to list all tracked jobs as JSON (last 100). |
+
+### Storage Backends
+
+| ID | Requirement |
+|---|---|
+| FR-PY13 | Jobs targeting `storage=local` read input artifacts from and write output artifacts to the local filesystem under the configured working directory. |
+| FR-PY14 | Jobs targeting `storage=minio` read input artifacts from and write output artifacts to a MinIO object store using the credentials in the job payload. |
+| FR-PY15 | Jobs targeting `storage=s3` read input artifacts from and write output artifacts to AWS S3 using the credentials in the job payload. |
+
+### Function Adapter Execution
+
+| ID | Requirement |
+|---|---|
+| FR-PY16 | The service exposes `POST /api/service/v1/function/execute` which executes a function adapter call (dynamic Python script generation and execution) from a structured request payload. |
+| FR-PY17 | The function adapter supports dynamic script generation: it assembles a Python script from imports, requirements, and execution-order blocks supplied in the request, installs missing packages via pip, and runs the script. |
+
+### Virtual Environment Management
+
+| ID | Requirement |
+|---|---|
+| FR-PY18 | The service exposes `GET /venvs` to list all virtual environments under the `venvs/` directory. |
+| FR-PY19 | The service exposes `DELETE /venvs` to delete one or more named virtual environments by name. |
+
+### Task Retriever Integration
+
+| ID | Requirement |
+|---|---|
+| FR-PY20 | When `use_task_retriver` is enabled in configuration, the service propagates job status transitions (RUNNING, COMPLETED, ERROR) to an external task-retriever module via async database updates. |
+
+### API Documentation
+
+| ID | Requirement |
+|---|---|
+| FR-PY21 | The service exposes a Swagger UI at `/swagger` and serves the OpenAPI spec at `/swagger.json`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-PY1 | Job submission (`POST /execute`) must respond in **< 200 ms**. Actual execution time depends on the pipeline script and its dependencies. |
+| NFR-PY2 | The thread pool size is configurable via `conf/conf.ini` (`ThreadCount`). Concurrent job execution is bounded by this setting. |
+| NFR-PY3 | Job state is persisted in a local SQLite database at `/data/app.db` using WAL mode. Job state survives application restarts within the same pod or container. |
+| NFR-PY4 | Task IDs are validated as well-formed UUIDs before any filesystem or database operation. All file paths are resolved and checked against the configured working directory to prevent path traversal attacks. |
+| NFR-PY5 | Package names in function-adapter requests are validated against a strict regex (`^[A-Za-z0-9_\-\.]+...`) before being passed to `pip install`. Shell injection via package names is not possible. |
+| NFR-PY6 | Security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block`) are applied to all responses. |
+| NFR-PY7 | Storage credentials from the job payload are never logged or returned in API responses. |
+| NFR-PY8 | The service runs as a Python Flask application. Port and working directory are configurable via `conf/conf.ini`. |

--- a/py-job-sagemaker-executer/docs/ARCHITECTURE.md
+++ b/py-job-sagemaker-executer/docs/ARCHITECTURE.md
@@ -1,0 +1,98 @@
+# SageMaker Job Executor — Architecture
+
+---
+
+## 1. Service Architecture
+
+Extends the base Python job executor pattern with a full **SageMaker MLOps API layer**. The base job execution engine (queue → thread pool → subprocess) is identical to the standard executor. The SageMaker-specific routes operate independently of the job queue — they call the SageMaker SDK directly and return synchronously or initiate async SageMaker jobs tracked by SageMaker itself.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        ICIP["ICIP Service"]
+    end
+
+    subgraph SageMaker Job Executor
+        BASE_API["Base Job API\n/execute/* endpoints"]
+        SM_API["SageMaker MLOps API\n/api/service/v1/*\ndatasets · models · endpoints\ntraining · inference · cloudconnect"]
+        QUEUE["In-Memory Queue"]
+        THREAD_POOL["ThreadPoolExecutor"]
+        TASK["Task Runner\nSubprocess + S3/MinIO I/O"]
+        DB["SQLite /data/app.db\n(WAL mode)"]
+        MLOPS["mlops/sagemaker.py\nSageMaker SDK calls"]
+        FUNC_ADAPTER["functionadapter.py\nDynamic script + pip"]
+    end
+
+    subgraph External
+        AWS_SM["AWS SageMaker\nTraining · Inference · AutoML\nModel Registry · Endpoints"]
+        S3["AWS S3\nDatasets · Artifacts"]
+    end
+
+    ICIP --> BASE_API & SM_API
+    BASE_API --> QUEUE --> THREAD_POOL --> TASK
+    TASK --> DB & S3
+    SM_API --> MLOPS --> AWS_SM & S3
+    SM_API --> FUNC_ADAPTER
+```
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| AWS SageMaker SDK (`sagemaker`) | External (HTTPS/SDK) | Training jobs, AutoML, endpoints, model registry, inference |
+| AWS S3 (`boto3`) | External (HTTPS/SDK) | Dataset storage, artifact upload/download |
+| SQLite (`/data/app.db`) | Local file | Job state persistence |
+| `conf/conf.ini` | Local file | Thread count, working directory |
+
+---
+
+## 3. Architectural Decisions
+
+### AD-SM1 — SageMaker MLOps API is synchronous (not queued)
+**Decision:** SageMaker dataset, model, endpoint, and pipeline API calls are handled synchronously via direct SDK calls — they do not go through the internal job queue.
+**Reason:** SageMaker SDK calls themselves return job IDs or resource ARNs quickly (the actual work runs on AWS infrastructure). Queuing them would add latency without benefit. Polling for SageMaker job completion is the responsibility of the caller via the status endpoints.
+
+### AD-SM2 — Shared SQLite store for base jobs only
+**Decision:** SQLite tracks only the base job-executor jobs (submitted via `/execute`). SageMaker MLOps operations (training jobs, endpoints) are tracked directly in AWS and surfaced via the status/list endpoints.
+**Reason:** SageMaker already maintains durable job state in AWS. Duplicating that into SQLite would create a consistency problem if the two stores diverged.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — SageMaker AutoML Training Job
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as SageMaker Executor
+    participant SDK as mlops/sagemaker.py
+    participant SM as AWS SageMaker
+
+    ICIP->>API: POST /api/service/v1/pipelines/training/automl {dataset, target_column, config}
+    API->>SDK: submit_automl_job(config)
+    SDK->>SM: CreateAutoMLJob (SDK)
+    SM-->>SDK: Job ARN
+    SDK-->>API: {job_id, status: "InProgress"}
+    API-->>ICIP: 200 OK {job_id}
+    Note over ICIP: Polls GET /api/service/v1/pipelines/training/{id}/get for status
+```
+
+### Flow 2 — Model Deployment to Endpoint
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as SageMaker Executor
+    participant SDK as mlops/sagemaker.py
+    participant SM as AWS SageMaker
+
+    ICIP->>API: POST /api/service/v1/endpoints/{endpoint_id}/deploy_model {model_id, instance_type}
+    API->>SDK: deploy_model(endpoint_id, model_id)
+    SDK->>SM: CreateEndpoint / UpdateEndpoint
+    SM-->>SDK: Endpoint ARN (creating)
+    SDK-->>API: {endpoint_id, status: "Creating"}
+    API-->>ICIP: 200 OK
+```

--- a/py-job-sagemaker-executer/docs/SCOPE.md
+++ b/py-job-sagemaker-executer/docs/SCOPE.md
@@ -1,0 +1,86 @@
+# SageMaker Job Executor — Scope
+
+## Objective
+
+Execute AI/ML pipeline jobs on **AWS SageMaker** on behalf of the Essedum platform. Beyond the base job execution capability shared with the standard Python executor, this service provides a full SageMaker MLOps API: dataset management, model registry, endpoint lifecycle, training pipelines (AutoML and custom script), inference pipelines, and cloud connectivity validation.
+
+---
+
+## Functional Requirements
+
+### Job Execution (shared with base executor)
+
+| ID | Requirement |
+|---|---|
+| FR-SM1 | The service accepts job submissions via `POST /execute`, queues them asynchronously, and returns a `task_id` immediately. |
+| FR-SM2 | Job status is queryable via `GET /execute/{task_id}/getStatus`, returning state, timestamps, PID, log path, and elapsed duration. |
+| FR-SM3 | Running or queued jobs can be cancelled via `GET /execute/{task_id}/stop` using OS process-tree termination. |
+| FR-SM4 | Per-job logs and output artifacts are retrievable via `GET /execute/{task_id}/getLog` and `GET /execute/{task_id}/getOutputArtifacts`. |
+| FR-SM5 | Service-level logs are retrievable via `GET /execute/getLog`. |
+| FR-SM6 | Job list (last 100) is available via `GET /execute` (JSON) and `GET /execute/jobs` (HTML dashboard). |
+
+### SageMaker Dataset Management
+
+| ID | Requirement |
+|---|---|
+| FR-SM7 | Users can create SageMaker datasets (S3-backed) via `POST /api/service/v1/datasets`. |
+| FR-SM8 | Users can list, retrieve, delete, and export datasets. |
+
+### SageMaker Model Registry
+
+| ID | Requirement |
+|---|---|
+| FR-SM9 | Users can register models in SageMaker's model registry via `POST /api/service/v1/models/register`. |
+| FR-SM10 | Users can list, retrieve, delete, and export registered models. |
+
+### SageMaker Endpoint Lifecycle
+
+| ID | Requirement |
+|---|---|
+| FR-SM11 | Users can register, list, and retrieve SageMaker inference endpoints. |
+| FR-SM12 | Users can deploy a registered model to a SageMaker endpoint via `POST /api/service/v1/endpoints/{endpoint_id}/deploy_model`. |
+| FR-SM13 | Users can run inference against a deployed endpoint via `POST /api/service/v1/endpoints/{endpoint_id}/infer`. |
+| FR-SM14 | Users can request model explanations via `POST /api/service/v1/endpoints/{endpoint_id}/explain`. |
+| FR-SM15 | Users can undeploy models from an endpoint and delete endpoints. |
+
+### Training Pipelines
+
+| ID | Requirement |
+|---|---|
+| FR-SM16 | Users can submit AutoML training jobs via `POST /api/service/v1/pipelines/training/automl`. |
+| FR-SM17 | Users can submit custom script training jobs via `POST /api/service/v1/pipelines/training/custom_script`. |
+| FR-SM18 | Users can submit general training runs via `POST /api/service/v1/pipelines/training/train`. |
+| FR-SM19 | Users can list, retrieve, cancel, and delete training jobs. |
+
+### Inference Pipelines
+
+| ID | Requirement |
+|---|---|
+| FR-SM20 | Users can submit inference pipeline jobs via `POST /api/service/v1/pipelines/inference`. |
+| FR-SM21 | Users can list, retrieve, cancel, and delete inference jobs. |
+
+### Cloud Connectivity & Function Adapter
+
+| ID | Requirement |
+|---|---|
+| FR-SM22 | Users can validate SageMaker cloud connectivity via `POST /cloudconnect`. |
+| FR-SM23 | The service supports dynamic function-adapter execution via `POST /api/service/v1/function/execute`. |
+
+### API Documentation
+
+| ID | Requirement |
+|---|---|
+| FR-SM24 | Swagger UI is available at `/swagger` and the spec at `/swagger.json`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-SM1 | Job submission returns in **< 200 ms**. SageMaker training and inference job duration is determined by AWS. |
+| NFR-SM2 | Thread pool size is configurable via `conf/conf.ini` (`ThreadCount`). |
+| NFR-SM3 | Job state is persisted in SQLite at `/data/app.db` with WAL mode. |
+| NFR-SM4 | AWS credentials are loaded from environment variables at runtime and never logged or returned in responses. |
+| NFR-SM5 | UUID validation and path traversal protection are enforced on all `/{task_id}/*` endpoints. |
+| NFR-SM6 | Security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`) are applied to all responses. |

--- a/py-job-vertex-executer/docs/ARCHITECTURE.md
+++ b/py-job-vertex-executer/docs/ARCHITECTURE.md
@@ -1,0 +1,99 @@
+# Vertex AI Job Executor — Architecture
+
+---
+
+## 1. Service Architecture
+
+Structurally identical to the SageMaker executor — the same base job execution engine (queue → thread pool → subprocess) plus a cloud MLOps API layer, targeting GCP Vertex AI instead of AWS SageMaker. The Vertex AI MLOps API calls are synchronous; actual training and inference workloads run on GCP infrastructure.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        ICIP["ICIP Service"]
+    end
+
+    subgraph Vertex AI Job Executor
+        BASE_API["Base Job API\n/execute/* endpoints"]
+        VX_API["Vertex AI MLOps API\n/api/service/v1/*\ndatasets · models · endpoints\ntraining · inference · cloudconnect"]
+        QUEUE["In-Memory Queue"]
+        THREAD_POOL["ThreadPoolExecutor"]
+        TASK["Task Runner\nSubprocess + GCS I/O"]
+        DB["SQLite /data/app.db\n(WAL mode)"]
+        MLOPS["mlops/vertex.py\nVertex AI SDK calls"]
+        FUNC_ADAPTER["functionadapter.py\nDynamic script + pip"]
+    end
+
+    subgraph External
+        GCP_VX["GCP Vertex AI\nTraining · AutoML\nModel Registry · Endpoints"]
+        GCS["Google Cloud Storage\nDatasets · Artifacts"]
+    end
+
+    ICIP --> BASE_API & VX_API
+    BASE_API --> QUEUE --> THREAD_POOL --> TASK
+    TASK --> DB & GCS
+    VX_API --> MLOPS --> GCP_VX & GCS
+    VX_API --> FUNC_ADAPTER
+```
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| GCP Vertex AI SDK (`google-cloud-aiplatform`) | External (HTTPS/SDK) | Training jobs, AutoML, endpoints, model registry |
+| Google Cloud Storage | External (HTTPS/SDK) | Dataset and artifact storage |
+| SQLite (`/data/app.db`) | Local file | Base job state persistence |
+| `conf/conf.ini` | Local file | Thread count, working directory |
+
+---
+
+## 3. Architectural Decisions
+
+### AD-VX1 — Mirror of SageMaker executor architecture
+**Decision:** The Vertex AI executor follows the exact same architectural pattern as the SageMaker executor — base job queue + cloud MLOps API layer, with the cloud SDK layer (`mlops/vertex.py`) being the only differentiator.
+**Reason:** The Essedum platform treats cloud ML platforms as interchangeable. A consistent executor structure means the ICIP Service uses the same protocol to communicate with all executors; only the target executor URL and the cloud-specific SDK differ.
+
+### AD-VX2 — GCP credentials via Application Default Credentials or env vars
+**Decision:** GCP authentication uses either a Service Account JSON file path (`GOOGLE_APPLICATION_CREDENTIALS` env var) or the GCP Application Default Credentials chain.
+**Reason:** This follows GCP's recommended credential pattern, supporting both Kubernetes Workload Identity (cluster-managed credentials) and explicit Service Account keys without code changes.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Vertex AI Custom Script Training
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Vertex Executor
+    participant SDK as mlops/vertex.py
+    participant VX as GCP Vertex AI
+    participant GCS as Google Cloud Storage
+
+    ICIP->>API: POST /api/service/v1/pipelines/training/custom_script {script_uri, config}
+    API->>SDK: submit_custom_training(config)
+    SDK->>GCS: Confirm training script URI exists
+    SDK->>VX: Create CustomJob (SDK)
+    VX-->>SDK: Job resource name
+    SDK-->>API: {job_id, status: "PENDING"}
+    API-->>ICIP: 200 OK {job_id}
+```
+
+### Flow 2 — Vertex AI Model Endpoint Inference
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant API as Vertex Executor
+    participant SDK as mlops/vertex.py
+    participant VX as GCP Vertex AI
+
+    ICIP->>API: POST /api/service/v1/endpoints/{endpoint_id}/infer {instances}
+    API->>SDK: predict(endpoint_id, instances)
+    SDK->>VX: Endpoint.predict() (SDK)
+    VX-->>SDK: predictions
+    SDK-->>API: {predictions}
+    API-->>ICIP: 200 OK {predictions}
+```

--- a/py-job-vertex-executer/docs/SCOPE.md
+++ b/py-job-vertex-executer/docs/SCOPE.md
@@ -1,0 +1,81 @@
+# Vertex AI Job Executor — Scope
+
+## Objective
+
+Execute AI/ML pipeline jobs on **GCP Vertex AI** on behalf of the Essedum platform. Structurally identical to the SageMaker executor, this service targets Google Cloud: dataset management, model registry, endpoint lifecycle, training pipelines, inference pipelines, and cloud connectivity validation — all against GCP Vertex AI APIs.
+
+---
+
+## Functional Requirements
+
+### Job Execution (shared with base executor)
+
+| ID | Requirement |
+|---|---|
+| FR-VX1 | The service accepts job submissions via `POST /execute`, queues them asynchronously, and returns a `task_id` immediately. |
+| FR-VX2 | Job status is queryable via `GET /execute/{task_id}/getStatus`. |
+| FR-VX3 | Running or queued jobs can be cancelled via `GET /execute/{task_id}/stop`. |
+| FR-VX4 | Per-job logs and output artifacts are retrievable via `GET /execute/{task_id}/getLog` and `GET /execute/{task_id}/getOutputArtifacts`. |
+| FR-VX5 | Service logs are retrievable via `GET /execute/getLog`. |
+| FR-VX6 | Job list (last 100) is available via `GET /execute` (JSON) and `GET /execute/jobs` (HTML). |
+
+### Vertex AI Dataset Management
+
+| ID | Requirement |
+|---|---|
+| FR-VX7 | Users can create, list, retrieve, delete, and export Vertex AI datasets. |
+
+### Vertex AI Model Registry
+
+| ID | Requirement |
+|---|---|
+| FR-VX8 | Users can register, list, retrieve, delete, and export models in the Vertex AI model registry. |
+
+### Vertex AI Endpoint Lifecycle
+
+| ID | Requirement |
+|---|---|
+| FR-VX9 | Users can register, list, and retrieve Vertex AI inference endpoints. |
+| FR-VX10 | Users can deploy a registered model to a Vertex AI endpoint. |
+| FR-VX11 | Users can run inference and explanations against deployed endpoints. |
+| FR-VX12 | Users can undeploy models and delete endpoints. |
+
+### Training Pipelines
+
+| ID | Requirement |
+|---|---|
+| FR-VX13 | Users can submit AutoML training jobs via `POST /api/service/v1/pipelines/training/automl`. |
+| FR-VX14 | Users can submit custom script training jobs via `POST /api/service/v1/pipelines/training/custom_script`. |
+| FR-VX15 | Users can submit general training runs, and list, retrieve, cancel, and delete training jobs. |
+
+### Inference Pipelines
+
+| ID | Requirement |
+|---|---|
+| FR-VX16 | Users can submit, list, retrieve, cancel, and delete inference pipeline jobs. |
+
+### Cloud Connectivity & Function Adapter
+
+| ID | Requirement |
+|---|---|
+| FR-VX17 | Users can validate Vertex AI cloud connectivity via `POST /cloudconnect`. |
+| FR-VX18 | The service supports dynamic function-adapter execution via `POST /api/service/v1/function/execute`. |
+
+### API Documentation
+
+| ID | Requirement |
+|---|---|
+| FR-VX19 | Swagger UI is available at `/swagger` and the spec at `/swagger.json`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-VX1 | Job submission returns in **< 200 ms**. Vertex AI job duration is determined by GCP. |
+| NFR-VX2 | Thread pool size is configurable via `conf/conf.ini` (`ThreadCount`). |
+| NFR-VX3 | Job state is persisted in SQLite at `/data/app.db` with WAL mode. |
+| NFR-VX4 | GCP credentials (Service Account JSON or Application Default Credentials) are loaded from environment variables at runtime and never logged or returned in responses. |
+| NFR-VX5 | UUID validation and path traversal protection are enforced on all `/{task_id}/*` endpoints. |
+| NFR-VX6 | Security headers are applied to all responses. |

--- a/s3proxy/docs/ARCHITECTURE.md
+++ b/s3proxy/docs/ARCHITECTURE.md
@@ -1,0 +1,78 @@
+# S3Proxy — Architecture
+
+---
+
+## 1. Service Architecture
+
+S3Proxy is a **protocol translation layer** — it speaks the S3 REST API to clients and translates each operation to the equivalent call on the configured jclouds backend. No business logic runs here; it is a thin translation proxy.
+
+```mermaid
+graph LR
+    subgraph Clients
+        PY_EXEC["Python Executors\n(boto3 / S3 SDK)"]
+        DATA_SVC["Data Service\n(S3 adapter)"]
+    end
+
+    subgraph S3Proxy
+        S3_API["S3 REST API\nBuckets · Objects · Multipart"]
+        AUTH["Auth Handler\nAnonymous or AWS Sig v2/v4"]
+        JCLOUDS["jclouds Backend Adapter\nFilesystem · Azure Blob\nGCP Storage · Swift"]
+    end
+
+    subgraph Storage
+        LOCAL["Local Filesystem"]
+        AZURE_BLOB["Azure Blob Storage"]
+        GCS["Google Cloud Storage"]
+    end
+
+    PY_EXEC -->|S3 API calls| S3_API
+    DATA_SVC -->|S3 API calls| S3_API
+    S3_API --> AUTH --> JCLOUDS
+    JCLOUDS --> LOCAL
+    JCLOUDS --> AZURE_BLOB
+    JCLOUDS --> GCS
+```
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Local filesystem | Local | Object storage backend for local/Docker deployments |
+| Azure Blob Storage | External (HTTPS) | Object storage backend for Azure deployments |
+| GCP Cloud Storage | External (HTTPS) | Object storage backend for GCP deployments |
+| `s3proxy.conf` | Local file | All configuration: endpoint, auth mode, backend type, credentials |
+
+S3Proxy has **no dependency on any other Essedum service**.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-S3P1 — Vendored open-source project, not a custom service
+**Decision:** S3Proxy is included as the upstream open-source `gaul/s3proxy` project with no custom application code added.
+**Reason:** The S3 protocol translation problem is fully solved by the upstream project. Building a custom implementation would duplicate significant work. All Essedum-specific configuration is in `s3proxy.conf`.
+
+### AD-S3P2 — Anonymous access for internal cluster deployments
+**Decision:** S3Proxy is configured with `s3proxy.authorization=none` for internal Essedum deployments.
+**Reason:** Access is controlled at the Kubernetes network policy level — only cluster-internal services reach S3Proxy. Requiring AWS credential validation for internal traffic would add complexity without meaningful security benefit.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Python Executor Uploads Artifact to Local Storage
+
+```mermaid
+sequenceDiagram
+    participant PY as Python Executor
+    participant S3P as S3Proxy
+    participant FS as Local Filesystem
+
+    PY->>S3P: PUT /bucket/project/artifacts/model.pkl (boto3)
+    S3P->>S3P: Validate bucket + object key
+    S3P->>FS: Write file to basedir/bucket/project/artifacts/model.pkl
+    FS-->>S3P: Write complete
+    S3P-->>PY: 200 OK (ETag)
+```

--- a/s3proxy/docs/SCOPE.md
+++ b/s3proxy/docs/SCOPE.md
@@ -1,0 +1,29 @@
+# S3Proxy — Scope
+
+## Objective
+
+Provide an **S3-compatible API facade** over non-S3 storage backends. S3Proxy (open-source, `gaul/s3proxy`) accepts standard Amazon S3 API calls and translates them to the underlying storage provider — including local filesystem, Azure Blob Storage, Google Cloud Storage, and others. In the Essedum platform, it is used to expose a local filesystem or alternative cloud storage as an S3-compatible endpoint so pipeline executors and data adapters that expect S3 can work without modification.
+
+---
+
+## Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| FR-S3P1 | The service implements the Amazon S3 REST API: `CreateBucket`, `DeleteBucket`, `ListBuckets`, `PutObject`, `GetObject`, `DeleteObject`, `ListObjectsV2`, `HeadObject`, `HeadBucket`, `CopyObject`, `MultipartUpload`. |
+| FR-S3P2 | The service supports the local filesystem as a storage backend, mapping S3 buckets to directories and objects to files. |
+| FR-S3P3 | The service supports Azure Blob Storage, GCP Cloud Storage, and other jclouds-supported backends as storage targets. |
+| FR-S3P4 | The service supports anonymous access mode (no AWS credential validation) for internal deployments where access is controlled at the network layer. |
+| FR-S3P5 | The service supports AWS Signature v2 and v4 authentication for deployments where credential validation is required. |
+| FR-S3P6 | Storage backend, endpoint, credentials, and access mode are configured via a properties file (`s3proxy.conf`) — no code changes are required to switch backends. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-S3P1 | The service is the upstream open-source project `gaul/s3proxy` version 2.x, built with Java 11+. It is included as a vendored component in the platform. |
+| NFR-S3P2 | The listening endpoint is configurable via `s3proxy.endpoint` in the properties file. |
+| NFR-S3P3 | In local filesystem mode, the base directory for all bucket/object storage is set via `jclouds.filesystem.basedir`. |
+| NFR-S3P4 | For production deployments, TLS termination is handled externally (Nginx or Kubernetes Ingress) — S3Proxy itself listens on plain HTTP in the Essedum deployment. |

--- a/sv/README.md
+++ b/sv/README.md
@@ -328,8 +328,6 @@ Docker Compose starts services in the correct order using health-check dependenc
 | `GET` | `/api/aip/service/v1/vibe-coding/config/providers` | List AI providers |
 | `GET` | `/api/aip/service/v1/vibe-coding/recipes/list` | List recipes |
 
-> **Full API reference with cURL examples →** [`API_TESTING_GUIDE.md`](./API_TESTING_GUIDE.md)
-
 ---
 
 ## Health Checks
@@ -421,8 +419,6 @@ TOKEN="<paste id_token here>"
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/userss
 ```
 
-> **Full cURL reference →** [`API_TESTING_GUIDE.md`](./API_TESTING_GUIDE.md)
-
 ---
 
 ## Troubleshooting
@@ -460,4 +456,3 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/userss
 
 - [Microservices Architecture Details](./MICROSERVICES_README.md)
 - [Decomposition Strategy & Rationale](./MICROSERVICES_DECOMPOSITION.md)
-- [Full API Testing Guide](./API_TESTING_GUIDE.md)

--- a/sv/api-gateway/docs/ARCHITECTURE.md
+++ b/sv/api-gateway/docs/ARCHITECTURE.md
@@ -1,0 +1,117 @@
+# API Gateway — Architecture
+
+---
+
+## 1. Service Architecture
+
+The gateway is a **thin routing layer** built on Spring Cloud Gateway. It holds no domain state and contains no business logic. Its only concerns are: validate the token, find the right service, forward the request.
+
+```mermaid
+graph LR
+    subgraph Inbound
+        CLIENT["Browser / VS Code / REST client"]
+    end
+
+    subgraph API Gateway
+        FILTER_AUTH["Auth Filter\nValidate JWT via Keycloak JWKS"]
+        FILTER_RATE["Rate Limit Filter\n1000 req/s per IP"]
+        FILTER_CORS["CORS Filter"]
+        FILTER_TRACE["Trace Header Filter\nX-Request-ID · X-Forwarded-For"]
+        ROUTER["Route Predicates\npath-based routing"]
+        LB["Load Balancer\nEureka-backed"]
+    end
+
+    subgraph Downstream
+        USM["USM Service"]
+        ICIP["ICIP Service"]
+        DATA["Data Service"]
+        VIBE["Vibe Service"]
+    end
+
+    CLIENT --> FILTER_AUTH --> FILTER_RATE --> FILTER_CORS --> FILTER_TRACE --> ROUTER --> LB
+    LB --> USM
+    LB --> ICIP
+    LB --> DATA
+    LB --> VIBE
+```
+
+**Filter chain order (every request):**
+1. Auth Filter — rejects with 401 if token is missing or invalid
+2. Rate Limit Filter — rejects with 429 if threshold exceeded
+3. CORS Filter — attaches response headers
+4. Trace Filter — stamps `X-Request-ID`; propagates `X-Forwarded-For`
+5. Router — matches path prefix, resolves service via Eureka, forwards
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Keycloak | External (HTTP) | JWK Set URI — fetch public keys to verify JWT signatures |
+| Eureka | Internal (HTTP) | Resolve current IP:port for each downstream service |
+| USM Service | Downstream | Receives `/api/usm/**` and `/api/authenticate` traffic |
+| ICIP Service | Downstream | Receives `/api/icip/**`, `/api/aip/**`, `/api/event/**` traffic |
+| Data Service | Downstream | Receives `/api/data/**`, `/api/file/**`, `/api/datasets/**` traffic |
+| Vibe Service | Downstream | Receives `/api/vibe/**`, `/api/goose/**`, `/api/github/**` traffic |
+
+The gateway has **no database** and calls **no external API** other than Keycloak JWKS and Eureka.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-GW1 — No business logic in the gateway
+The gateway only routes and enforces cross-cutting policies. Any logic that relates to users, jobs, or data lives in the domain services. This keeps the gateway simple and ensures it never becomes a bottleneck for feature changes.
+
+### AD-GW2 — Token validation at the edge, not in each service
+JWT validation happens once at the gateway using Keycloak's JWK Set URI. Downstream services trust that any request that reaches them has already been authenticated. This avoids repeating validation logic across four services and ensures key rotation is handled in one place.
+
+### AD-GW3 — Dynamic routing via Eureka (no hardcoded IPs)
+Service addresses are resolved at request time from Eureka. When a new pod starts, it registers itself automatically; the gateway picks it up within seconds. This is essential in Kubernetes where pod IPs change on every restart.
+
+### AD-GW4 — Stateless design
+The gateway holds no session state. Any gateway instance can handle any request. This makes horizontal scaling straightforward — add more gateway pods behind the load balancer.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Authenticated API Request
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant GW as API Gateway
+    participant KC as Keycloak (JWKS)
+    participant EUR as Eureka
+    participant SVC as Domain Service
+
+    C->>GW: HTTP request + Bearer token
+    GW->>KC: Fetch public keys (cached, refreshed on rotation)
+    GW->>GW: Validate token signature + expiry
+    alt Token invalid
+        GW-->>C: 401 Unauthorized
+    else Token valid
+        GW->>EUR: Resolve service address for path prefix
+        GW->>SVC: Forward request + trace headers
+        SVC-->>GW: Response
+        GW-->>C: Response
+    end
+```
+
+### Flow 2 — Service Instance Scale-Out
+
+```mermaid
+sequenceDiagram
+    participant NEW as New Service Pod
+    participant EUR as Eureka
+    participant GW as API Gateway
+
+    NEW->>EUR: Register (service name, IP, port, health URL)
+    EUR-->>NEW: Registration confirmed
+    Note over GW,EUR: Next request to that service path
+    GW->>EUR: Discover instances for service name
+    EUR-->>GW: Returns [instance-1, instance-2, new-instance]
+    GW->>NEW: Load-balanced request reaches new pod
+```

--- a/sv/api-gateway/docs/SCOPE.md
+++ b/sv/api-gateway/docs/SCOPE.md
@@ -1,0 +1,36 @@
+# API Gateway — Scope
+
+## Objective
+
+Act as the **sole public entry point** for all client traffic. Authenticate every request, route it to the correct downstream service, and enforce platform-wide policies — without containing any business logic.
+
+---
+
+## Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| FR-GW1 | All incoming HTTP requests must pass through the gateway. Downstream services (ports 8081–8084) are not directly reachable from outside the cluster. |
+| FR-GW2 | The gateway validates the JWT token on every request before forwarding. Requests with a missing or invalid token are rejected with HTTP 401. |
+| FR-GW3 | Requests are routed to USM, ICIP, Data, or Vibe service based on the URL path prefix (`/api/usm/**`, `/api/icip/**`, `/api/data/**`, `/api/vibe/**`). |
+| FR-GW4 | Service addresses are resolved dynamically via Eureka. No downstream URL is hardcoded in the gateway configuration. |
+| FR-GW5 | The gateway load-balances across multiple instances of the same service using Eureka-registered addresses. |
+| FR-GW6 | CORS headers are applied centrally at the gateway for all responses. |
+| FR-GW7 | Request body size is capped at 500 MB. Requests exceeding this are rejected with HTTP 413. |
+| FR-GW8 | The gateway propagates tracing headers (`X-Request-ID`, `X-Forwarded-For`) to downstream services on every forwarded request. |
+| FR-GW9 | Rate limiting is enforced per client IP at the gateway layer. |
+| FR-GW10 | The gateway exposes a `/health` endpoint for Kubernetes liveness and readiness probes. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-GW1 | The gateway must handle **≥ 1,000 req/s** at steady state without dropping requests. |
+| NFR-GW2 | Gateway-added latency must be **< 10 ms** (p99) on top of the downstream service response time. |
+| NFR-GW3 | The gateway must be **stateless** — any instance can handle any request. No session state is stored in the gateway process. |
+| NFR-GW4 | Token validation must use the Keycloak JWK Set URI, not a locally cached secret, so key rotation is handled automatically. |
+| NFR-GW5 | The gateway must recover from a downstream service outage without crashing. Unavailable routes return HTTP 503; other routes continue operating. |
+| NFR-GW6 | Configuration (routes, Eureka URL, token issuer URI) is injected via environment variables or a config file — no hardcoded values. |
+| NFR-GW7 | The gateway must be independently deployable and scalable without redeploying any domain service. |

--- a/sv/data-service/docs/ARCHITECTURE.md
+++ b/sv/data-service/docs/ARCHITECTURE.md
@@ -1,0 +1,168 @@
+# Data Service — Architecture
+
+> **OpenAPI Spec:** [`docs/openapi.yaml`](openapi.yaml) — generated automatically on every push to main by the [`openapi-spec`](../../../.github/workflows/openapi-spec.yml) workflow. Import into Postman, Swagger Editor, or any OpenAPI-compatible tool.
+
+---
+
+## 1. Service Architecture
+
+Data Service is a **storage and connectivity hub**. It has two distinct responsibilities handled by the same process: a file server for binary assets, and an adapter framework that lets pipelines read from and write to external data sources through a uniform interface.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        GW["API Gateway"]
+        KAFKA_IN["Kafka / RabbitMQ\n(stream inputs)"]
+    end
+
+    subgraph Data Service
+        CTL["REST Controllers\nFiles · Folders · Datasets · Datasources · Schemas · Adapters"]
+        SVC["Service Layer\nFile management · Dataset registration · Adapter orchestration"]
+        FILE_SVC["File Server\nUpload · Download · Folder mgmt"]
+        ADAPTER_FW["Adapter Framework\nPlugin interface — one impl per source type"]
+        SEARCH_IDX["Lucene Index\nFull-text search over datasets + files"]
+        STREAM_SVC["Stream Consumer\nKafka / RabbitMQ topic ingestion"]
+        PARSER["Data Parsers\nCSV · Excel · PDF → normalised rows"]
+    end
+
+    subgraph Storage
+        DB[("MySQL\nessedum_data")]
+        LOCAL["Local Filesystem"]
+        S3["AWS S3 / MinIO"]
+        AZBLOB["Azure Blob Storage"]
+    end
+
+    subgraph Adapter Targets
+        MYSQL_EXT["MySQL (external)"]
+        PG_EXT["PostgreSQL (external)"]
+        REST_EXT["REST APIs"]
+        GCP_GCS["GCP Cloud Storage"]
+        SAGE["AWS SageMaker"]
+        VERTEX["GCP Vertex AI"]
+        REMOTE["Remote Executor"]
+    end
+
+    GW --> CTL --> SVC
+    SVC --> FILE_SVC
+    SVC --> ADAPTER_FW
+    SVC --> SEARCH_IDX
+    SVC --> PARSER
+    KAFKA_IN --> STREAM_SVC --> SVC
+
+    FILE_SVC --> LOCAL
+    FILE_SVC --> S3
+    FILE_SVC --> AZBLOB
+    SVC --> DB
+
+    ADAPTER_FW --> MYSQL_EXT
+    ADAPTER_FW --> PG_EXT
+    ADAPTER_FW --> REST_EXT
+    ADAPTER_FW --> GCP_GCS
+    ADAPTER_FW --> SAGE
+    ADAPTER_FW --> VERTEX
+    ADAPTER_FW --> REMOTE
+```
+
+**Key internal subsystems:**
+- **File Server** — handles binary I/O. Storage backend (local/S3/Azure) is selected at runtime based on configuration; the rest of the service does not know which backend is active.
+- **Adapter Framework** — each external data source type is implemented as an adapter plugin. All adapters implement the same interface (`read`, `write`, `schema`). Pipelines call the framework; the framework delegates to the correct adapter.
+- **Lucene Index** — maintained locally per service instance, updated on every file/dataset mutation. Used for keyword search within a project's data.
+- **Data Parsers** — normalise uploaded CSV/Excel/PDF files into row-column records before indexing or dataset registration.
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| MySQL (`essedum_data`) | Internal DB | File metadata, dataset definitions, datasource configs, schema registry |
+| Local Filesystem | Storage | Binary file storage in single-node / Docker deployments |
+| AWS S3 / MinIO | Storage | Object storage for cloud / Kubernetes deployments |
+| Azure Blob Storage | Storage | Object storage for Azure-hosted deployments |
+| MySQL (external) | Adapter target | Read/write user-connected databases |
+| PostgreSQL (external) | Adapter target | Read/write user-connected databases |
+| REST APIs (external) | Adapter target | Fetch data from user-configured HTTP endpoints |
+| GCP Cloud Storage | Adapter target | Read/write files in GCS buckets |
+| AWS SageMaker / GCP Vertex AI | Adapter target | Interact with cloud ML data channels |
+| Kafka / RabbitMQ | Messaging | Consume streaming data; publish data outputs |
+
+Data Service has **no dependency on USM, ICIP, or Vibe services** at runtime.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-DATA1 — Storage backend abstracted behind an interface
+The file server delegates all I/O to a pluggable storage backend (local, S3, Azure Blob). The selection is configuration-driven. The rest of the service — controllers, service layer, metadata DB — is identical regardless of backend. This lets the platform run on a laptop (local) or in production (S3) without code changes.
+
+### AD-DATA2 — Adapter framework as a plugin registry
+Each adapter is a self-contained module implementing a common interface. Adding a new data source type requires adding a new adapter module and registering it — no changes to the framework or existing adapters. This is the primary extension point of the service.
+
+### AD-DATA3 — Metadata in MySQL, binaries in object storage
+File metadata (name, size, project, path) is stored in MySQL for fast querying. Binary content lives in the storage backend. This separation means the database stays small and fast regardless of file sizes.
+
+### AD-DATA4 — Per-project data isolation enforced at the service layer
+Every query and file operation is filtered by the project ID extracted from the user's token. This is enforced in the service layer, not the UI. A user in Project A cannot enumerate, read, or search data belonging to Project B even with a crafted API call.
+
+### AD-DATA5 — Lucene index co-located with the service instance
+The search index runs in-process (no external search cluster required). For the current scale target (millions of documents per deployment) this is sufficient. The trade-off is that index is not shared across service instances — each instance indexes independently. If full cross-instance search is needed in future, a migration to Elasticsearch/OpenSearch is the intended path.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — File Upload
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant GW as API Gateway
+    participant DATA as Data Service
+    participant STORE as Storage Backend (S3/local)
+    participant DB as MySQL
+
+    U->>GW: POST /api/data/files (multipart, Bearer token)
+    GW->>DATA: Forward
+    DATA->>DATA: Validate project scope from token
+    DATA->>DATA: Parse filename, size, MIME type
+    DATA->>STORE: Stream binary to storage backend
+    STORE-->>DATA: Storage path / object key
+    DATA->>DB: Insert file metadata record
+    DATA->>DATA: Update Lucene index (async)
+    DATA-->>U: 201 Created {fileId, path}
+```
+
+### Flow 2 — Pipeline Reads from External Database via Adapter
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service (via Python Executor)
+    participant DATA as Data Service
+    participant VAULT as Vault
+    participant EXT_DB as External MySQL/PostgreSQL
+
+    ICIP->>DATA: GET /api/data/adapters/{datasourceId}/query {sql}
+    DATA->>DB: Load datasource config (host, db name, credential ref)
+    DATA->>VAULT: Fetch DB credentials
+    VAULT-->>DATA: username + password
+    DATA->>EXT_DB: Execute query
+    EXT_DB-->>DATA: Result rows
+    DATA-->>ICIP: 200 OK [rows as JSON]
+```
+
+### Flow 3 — Dataset Registration with Schema
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant DATA as Data Service
+    participant DB as MySQL
+    participant LUCENE as Lucene Index
+
+    U->>DATA: POST /api/data/datasets {fileId, columns: [{name, type}]}
+    DATA->>DB: Load file record (validate project scope)
+    DATA->>DB: Insert dataset + schema columns
+    DATA->>LUCENE: Index dataset name + column names
+    DATA-->>U: 201 Created {datasetId}
+    Note over DATA: Dataset is now available<br/>for pipeline input selection
+```

--- a/sv/data-service/docs/SCOPE.md
+++ b/sv/data-service/docs/SCOPE.md
@@ -1,0 +1,67 @@
+# Data Service — Scope
+
+## Objective
+
+Be the **single source of truth for all data** in the platform — files, datasets, datasource connections, and schema metadata. Provide a pluggable adapter layer so pipelines can read from and write to any supported storage or database without knowing the underlying technology.
+
+---
+
+## Functional Requirements
+
+### File Management
+
+| ID | Requirement |
+|---|---|
+| FR-DATA1 | Users can upload files and binary assets to the platform via the UI or API. Upload size limit is 500 MB per file. |
+| FR-DATA2 | Users can browse, preview, download, and delete files through a folder hierarchy scoped to their project. |
+| FR-DATA3 | Files can be stored on local disk, AWS S3 / MinIO, or Azure Blob Storage depending on the deployment configuration. |
+| FR-DATA4 | Partial or failed uploads are cleaned up automatically — no orphaned partial files remain on storage. |
+
+### Dataset & Schema Management
+
+| ID | Requirement |
+|---|---|
+| FR-DATA5 | Users can register datasets with column schema metadata (name, type, description) for use in pipelines. |
+| FR-DATA6 | The service maintains a schema registry that pipelines reference to validate their inputs and outputs. |
+| FR-DATA7 | Users can connect external databases (MySQL, PostgreSQL) as named datasources and browse their schema. |
+| FR-DATA8 | Datasets support CSV, Excel, and PDF as source formats. The service parses and normalises these on ingestion. |
+
+### Data Adapters
+
+| ID | Requirement |
+|---|---|
+| FR-DATA9 | The service provides a pluggable adapter framework. Each adapter implements a standard interface for read, write, and schema discovery. |
+| FR-DATA10 | Supported adapters: REST API, MySQL, PostgreSQL, AWS S3 / MinIO, Azure Blob Storage, GCP Cloud Storage, AWS SageMaker, GCP Vertex AI, remote execution. |
+| FR-DATA11 | Adapter credentials are stored securely and associated with a named datasource. Credentials are never returned in API responses. |
+| FR-DATA12 | Adding a new adapter does not require changes to any other service. |
+
+### Search
+
+| ID | Requirement |
+|---|---|
+| FR-DATA13 | File and dataset content is indexed for full-text search using Apache Lucene. |
+| FR-DATA14 | Users can search across all files and datasets within their project using keyword queries. |
+| FR-DATA15 | Search index is updated automatically when files or datasets are added, updated, or deleted. |
+
+### Streaming
+
+| ID | Requirement |
+|---|---|
+| FR-DATA16 | The service can consume data from Kafka and RabbitMQ topics and make them available as pipeline inputs. |
+| FR-DATA17 | The service can publish data to Kafka topics as a pipeline output. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-DATA1 | File upload and download throughput must be **≥ 100 MB/s** on local storage. Cloud storage throughput is bounded by the provider. |
+| NFR-DATA2 | Dataset search queries must return results in **< 1 second** for indices up to 10 million documents. |
+| NFR-DATA3 | The service must handle **concurrent uploads from multiple users** without file collision or data corruption. |
+| NFR-DATA4 | Adapter connections are pooled and reused. Creating a new adapter instance must not open an unbounded number of connections. |
+| NFR-DATA5 | The service is stateless. File metadata is stored in the database; binary content is stored on the configured storage backend. |
+| NFR-DATA6 | Database connection pool is capped at **25 connections** to prevent MySQL exhaustion. |
+| NFR-DATA7 | Datasource credentials are retrieved at runtime from the secrets manager. They are never stored as plaintext in the database. |
+| NFR-DATA8 | The service exposes `/actuator/health` for Kubernetes liveness and readiness probes. |
+| NFR-DATA9 | Data is scoped per project. A user in Project A cannot read, list, or search files belonging to Project B. |

--- a/sv/data-service/pom.xml
+++ b/sv/data-service/pom.xml
@@ -28,7 +28,7 @@
         <json-simple.version>1.1.1</json-simple.version>
         <commons-io.version>2.17.0</commons-io.version>
         <gson.version>2.14.0</gson.version>
-        <springdoc-openapi-ui.version>1.6.6</springdoc-openapi-ui.version>
+        <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
         <joda-time.version>2.10.6</joda-time.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <poi.version>5.4.0</poi.version>
@@ -152,7 +152,7 @@
         <dependency><groupId>com.azure</groupId><artifactId>azure-core-http-okhttp</artifactId><version>${azure-core-http-okhttp.version}</version></dependency>
         <dependency><groupId>com.azure</groupId><artifactId>azure-ai-textanalytics</artifactId><version>${azure-ai-textanalytics.version}</version></dependency>
         <dependency><groupId>com.microsoft.graph</groupId><artifactId>microsoft-graph</artifactId><version>${microsoft-graph.version}</version></dependency>
-        <dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-ui</artifactId><version>${springdoc-openapi-ui.version}</version></dependency>
+        <dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-ui</artifactId><version>${springdoc-openapi.version}</version></dependency>
         <dependency><groupId>io.micrometer</groupId><artifactId>micrometer-registry-prometheus</artifactId><version>${micrometer-prometheus.version}</version></dependency>
         <dependency><groupId>com.sun.xml.bind</groupId><artifactId>jaxb-impl</artifactId><version>${jaxb-impl.version}</version><scope>runtime</scope></dependency>
         <dependency><groupId>jakarta.xml.bind</groupId><artifactId>jakarta.xml.bind-api</artifactId><version>${jakarta-xml-bind.version}</version></dependency>
@@ -194,6 +194,8 @@
         <dependency><groupId>commons-fileupload</groupId><artifactId>commons-fileupload</artifactId><version>${commons-fileupload.version}</version></dependency>
         <dependency><groupId>com.jayway.jsonpath</groupId><artifactId>json-path</artifactId></dependency>
         <dependency><groupId>wsdl4j</groupId><artifactId>wsdl4j</artifactId></dependency>
+        <!-- H2 in-memory DB — used only by the generate-openapi Maven profile -->
+        <dependency><groupId>com.h2database</groupId><artifactId>h2</artifactId><scope>runtime</scope></dependency>
     </dependencies>
     <build>
         <plugins>
@@ -208,5 +210,59 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+          generate-openapi profile
+          Usage: mvn verify -P generate-openapi -pl sv/data-service -am -Dmaven.test.skip=true
+          Starts the service with an H2 in-memory profile, generates docs/openapi.yaml,
+          then stops the service. Run from the sv/ directory or the repo root.
+        -->
+        <profile>
+            <id>generate-openapi</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>start-for-openapi</id>
+                                <goals><goal>start</goal></goals>
+                                <phase>pre-integration-test</phase>
+                                <configuration>
+                                    <arguments>
+                                        <argument>--spring.profiles.active=dbjwt,openapi</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-for-openapi</id>
+                                <goals><goal>stop</goal></goals>
+                                <phase>post-integration-test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-maven-plugin</artifactId>
+                        <version>2.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>generate-openapi-spec</id>
+                                <goals><goal>generate</goal></goals>
+                                <phase>integration-test</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <apiDocsUrl>http://localhost:8083/v3/api-docs.yaml</apiDocsUrl>
+                            <outputFileName>openapi.yaml</outputFileName>
+                            <outputDir>${project.basedir}/docs</outputDir>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
 

--- a/sv/data-service/src/main/java/com/lfn/common/app/config/SwaggerConfig.java
+++ b/sv/data-service/src/main/java/com/lfn/common/app/config/SwaggerConfig.java
@@ -15,7 +15,7 @@
 
 package com.lfn.common.app.config;
 
-import org.springdoc.core.GroupedOpenApi;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/sv/data-service/src/main/java/com/lfn/common/app/security/config/CustomAuthSecurityConfig.java
+++ b/sv/data-service/src/main/java/com/lfn/common/app/security/config/CustomAuthSecurityConfig.java
@@ -112,6 +112,9 @@ class CustomAuthSecurityConfig {
 			http.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry
 					.requestMatchers(PATH_MATCHERS.matcher(ACTUATOR_PATTERN)).permitAll()
 					.requestMatchers(PATH_MATCHERS.matcher("/error/**")).permitAll()
+					.requestMatchers(PATH_MATCHERS.matcher("/swagger-ui/**")).permitAll()
+					.requestMatchers(PATH_MATCHERS.matcher("/swagger-ui.html")).permitAll()
+					.requestMatchers(PATH_MATCHERS.matcher("/v3/api-docs/**")).permitAll()
 					.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 					.requestMatchers(PATH_MATCHERS.matcher(LANGFLOW_AGENT_EXPORT)).permitAll()
 					.requestMatchers(PATH_MATCHERS.matcher("/api/aip/langflow/get_langflow_agent_export")).permitAll()
@@ -127,6 +130,9 @@ class CustomAuthSecurityConfig {
 				authorizationManagerRequestMatcherRegistry
 						.requestMatchers(PATH_MATCHERS.matcher(ACTUATOR_PATTERN)).permitAll()
 						.requestMatchers(PATH_MATCHERS.matcher("/error/**")).permitAll()
+						.requestMatchers(PATH_MATCHERS.matcher("/swagger-ui/**")).permitAll()
+						.requestMatchers(PATH_MATCHERS.matcher("/swagger-ui.html")).permitAll()
+						.requestMatchers(PATH_MATCHERS.matcher("/v3/api-docs/**")).permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(PATH_MATCHERS.matcher(LANGFLOW_AGENT_EXPORT)).permitAll()
                         .requestMatchers(PATH_MATCHERS.matcher("/api/aip/langflow/get_langflow_agent_export")).permitAll()

--- a/sv/data-service/src/main/resources/application-openapi.yml
+++ b/sv/data-service/src/main/resources/application-openapi.yml
@@ -1,0 +1,113 @@
+# -----------------------------------------------------------------------
+# application-openapi.yml
+#
+# Activation: spring.profiles.active=dbjwt,openapi
+#
+# Purpose: Allow the service to start without any external infrastructure
+# (MySQL, Kafka, RabbitMQ, Vault, Azure KV) so that the springdoc-openapi-
+# maven-plugin can call /v3/api-docs.yaml and write docs/openapi.yaml.
+#
+# This profile MUST NOT be used for any runtime environment.
+# -----------------------------------------------------------------------
+
+server:
+  port: 8083
+
+# ── All datasources → H2 in-memory ──────────────────────────────────────
+# The service has four named datasource configs:
+#   spring.datasource     → DashboardDbConfig  (primary / dashboard)
+#   icip.datasource       → ICIPDbConfig + ICIPModDBConfig
+#   quartz.datasource     → ICIPQuartzDbConfig
+#   telemetry.datasource  → TelemetryDbConfig
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:dashboard;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+  # In-memory Quartz (no DB required)
+  quartz:
+    job-store-type: memory
+
+  # Disable auto-configurations that require external services
+  autoconfigure:
+    exclude:
+      - org.springframework.cloud.vault.config.VaultAutoConfiguration
+      - org.springframework.cloud.vault.config.VaultBootstrapPropertySourceConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+      - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+
+  # Disable Vault bootstrap
+  cloud:
+    vault:
+      enabled: false
+    config:
+      enabled: false
+
+  # Mail — stub (no actual sending during spec generation)
+  mail:
+    host: localhost
+    port: 25
+
+icip:
+  datasource:
+    url: jdbc:h2:mem:icipdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+
+quartz:
+  datasource:
+    url: jdbc:h2:mem:quartzdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+
+telemetry:
+  datasource:
+    url: jdbc:h2:mem:telemetrydb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+
+# ── Security ─────────────────────────────────────────────────────────────
+# dbjwt profile requires a jwt.secret and csrf config
+jwt:
+  secret: openapi-generation-placeholder-secret-not-for-production-use
+  expiration: 86400
+
+csrf:
+  ignore:
+    urls: /api/**,/swagger-ui/**,/v3/api-docs/**,/actuator/**
+
+# ── Placeholders for @Value-injected properties ──────────────────────────
+encryption:
+  key: openapi-placeholder-key
+  salt: openapi-placeholder-salt
+
+license: placeholder
+publickey: placeholder
+
+# ── Springdoc ────────────────────────────────────────────────────────────
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+  packages-to-scan: com.lfn

--- a/sv/docs/ARCHITECTURE.md
+++ b/sv/docs/ARCHITECTURE.md
@@ -1,0 +1,197 @@
+# Backend Services — Architecture
+
+---
+
+## 1. Overview
+
+The backend is structured as **five independently deployable services** sitting behind a single entry point. All external traffic hits the API Gateway; it inspects the URL path and forwards the request to the correct domain service. Services find each other through a central service registry (Eureka) — no hardcoded addresses between services.
+
+```mermaid
+graph TB
+    subgraph Clients
+        UI["Angular UI"]
+        EXT["External / REST clients"]
+    end
+
+    subgraph Backend
+        GW["API Gateway\n:8080\nrouting · auth filter · rate limit"]
+        EUR["Eureka\n:8761\nservice registry"]
+        USM["USM Service :8081\nUsers · Roles · Orgs"]
+        ICIP["ICIP Service :8082\nPipelines · Jobs · Models"]
+        DATA["Data Service :8083\nFiles · Datasets · Adapters"]
+        VIBE["Vibe Service :8084\nAI Coding · GitHub Sync"]
+    end
+
+    UI --> GW
+    EXT --> GW
+    GW --> USM
+    GW --> ICIP
+    GW --> DATA
+    GW --> VIBE
+    GW <--> EUR
+    USM <--> EUR
+    ICIP <--> EUR
+    DATA <--> EUR
+    VIBE <--> EUR
+```
+
+---
+
+## 2. Services
+
+### API Gateway — Port 8080
+The sole entry point for all traffic.
+
+- Validates JWT / OAuth2 tokens before forwarding any request.
+- Routes based on URL path prefix — no business logic lives here.
+- Applies global rate limiting and enforces the 500 MB request size cap.
+- Discovers downstream service addresses dynamically via Eureka.
+
+### USM Service — Port 8081
+Owns everything related to **who can do what**.
+
+- Authentication (JWT, OAuth2 via Keycloak).
+- User, role, organisation, and project management.
+- Permission checks — defines the RBAC model the entire platform relies on.
+- Secrets integration with HashiCorp Vault / Azure Key Vault.
+- Own database: `essedum_usm`.
+
+### ICIP Service — Port 8082
+The **AI/ML execution engine** — the largest and most complex service.
+
+- Runs Python-based training, inference, and RAG pipelines.
+- Schedules jobs (Quartz), triggers them on events, and streams status in real time via WebSocket.
+- Manages the model registry and ML endpoints.
+- Submits jobs to AWS SageMaker, GCP Vertex AI, and Azure ML.
+- Generates code using LLM APIs (Azure OpenAI, Bedrock, Vertex AI).
+- Publishes execution events to Kafka and RabbitMQ.
+- Own databases: `essedum_core` (main), Quartz scheduler DB, model registry DB.
+
+### Data Service — Port 8083
+Manages **all data at rest and in motion**.
+
+- File upload, download, and folder management.
+- Connects to external sources via adapters: MySQL, PostgreSQL, REST, AWS S3/MinIO, Azure Blob, GCP Storage, SageMaker, Vertex AI.
+- Dataset and schema registry management.
+- Full-text search over ingested content (Apache Lucene).
+- Consumes streaming data from Kafka / RabbitMQ topics.
+- Own database: `essedum_data`.
+
+### Vibe Service — Port 8084
+Provides **AI-assisted coding** capabilities.
+
+- Relays coding requests to the Goose AI engine; streams responses back via SSE.
+- Manages AI coding sessions and recipes.
+- Pushes generated code to GitHub and opens pull requests.
+- Handles GitHub OAuth flow.
+- Own database: `essedum_vibe`.
+
+---
+
+## 3. Dependency Map
+
+The diagram below shows which service depends on which external system. Arrows point from consumer to provider.
+
+```mermaid
+graph LR
+    GW["API Gateway"]
+    USM["USM Service"]
+    ICIP["ICIP Service"]
+    DATA["Data Service"]
+    VIBE["Vibe Service"]
+
+    subgraph Databases
+        DB_USM[("essedum_usm")]
+        DB_ICIP[("essedum_core\n+ Quartz DB\n+ Model DB")]
+        DB_DATA[("essedum_data")]
+        DB_VIBE[("essedum_vibe")]
+    end
+
+    subgraph Messaging
+        KAFKA["Kafka"]
+        RABBIT["RabbitMQ"]
+    end
+
+    subgraph Storage
+        S3["AWS S3 / MinIO"]
+        AZBLOB["Azure Blob"]
+    end
+
+    subgraph CloudML
+        SAGEMAKER["AWS SageMaker"]
+        VERTEX["GCP Vertex AI"]
+        AZUREML["Azure ML"]
+    end
+
+    subgraph AIServices
+        GOOSE["Goose AI"]
+        LLM["LLM APIs\nOpenAI · Bedrock · Gemini"]
+        GITHUB["GitHub"]
+    end
+
+    subgraph Security
+        KC["Keycloak / OIDC"]
+        VAULT["Vault / Azure KV"]
+    end
+
+    GW --> KC
+    USM --> DB_USM
+    USM --> VAULT
+    ICIP --> DB_ICIP
+    ICIP --> KAFKA
+    ICIP --> RABBIT
+    ICIP --> SAGEMAKER
+    ICIP --> VERTEX
+    ICIP --> AZUREML
+    ICIP --> LLM
+    DATA --> DB_DATA
+    DATA --> S3
+    DATA --> AZBLOB
+    DATA --> KAFKA
+    DATA --> RABBIT
+    VIBE --> DB_VIBE
+    VIBE --> GOOSE
+    VIBE --> GITHUB
+```
+
+**Key rule:** Domain services do **not** call each other directly. Cross-domain data (e.g., ICIP needing user context) is passed in the request by the gateway or resolved via shared database conventions — never via a synchronous service-to-service HTTP call.
+
+---
+
+## 4. Architectural Decisions
+
+### AD-1 — Monolith split into four domain services
+**Decision:** Decompose the original single deployable into USM, ICIP, Data, and Vibe services.  
+**Reason:** The monolith had a single point of failure, could not be scaled per workload, and had dangerously high database connection counts (600+). Each domain now scales independently.
+
+### AD-2 — API Gateway as the only public entry point
+**Decision:** All external traffic enters exclusively through the gateway on port 8080. Ports 8081–8084 are internal only.  
+**Reason:** Centralises authentication, rate limiting, and routing. Downstream services can trust that the token has already been validated before they see the request.
+
+### AD-3 — Service discovery via Eureka (not hardcoded addresses)
+**Decision:** Services register themselves with Eureka at startup; the gateway resolves addresses dynamically.  
+**Reason:** Pod IPs change constantly in Kubernetes. Eureka removes the need for hardcoded service URLs and enables automatic load balancing across multiple instances of the same service.
+
+### AD-4 — One database per service
+**Decision:** Each service owns its schema and no service reads another service's database directly.  
+**Reason:** Database-level isolation prevents tight coupling. A schema change in USM cannot break the ICIP service. It also caps connection pool size per service, solving the connection exhaustion problem.
+
+### AD-5 — Asynchronous job execution via message queues
+**Decision:** Long-running pipeline and ML jobs are triggered and tracked asynchronously via Kafka / RabbitMQ, not via synchronous HTTP calls.  
+**Reason:** ML jobs can run for hours. Keeping an HTTP connection open that long is unreliable. Queues decouple the job submission from execution and make retries straightforward.
+
+### AD-6 — Real-time status via WebSocket and SSE
+**Decision:** Job execution progress is pushed to the UI over WebSocket (jobs) and SSE (Vibe / AI coding). The UI does not poll.  
+**Reason:** Polling at scale wastes server resources and introduces latency. Push-based updates give instant feedback with minimal overhead.
+
+### AD-7 — Spring profiles for environment configuration
+**Decision:** Environment-specific behaviour (auth mode, DB type, secrets backend) is switched via Spring profiles (`mysql`, `oauth2`, `vault`, `btf`) — not via code branches.  
+**Reason:** The same binary runs in local dev (DB JWT, no Vault) and production (Keycloak, Vault) without modification. Reduces environment-specific bugs.
+
+### AD-8 — Shared libraries for cross-cutting concerns
+**Decision:** Security filters, JWT utilities, and common REST helpers live in shared libraries (`comm-lib-util`, `common-lib-rest`, `comm-lib-secrets`) consumed by all services.  
+**Reason:** Avoids duplicating security logic across four services. A security fix ships to all services by bumping the shared library version.
+
+### AD-9 — Python executors as separate processes
+**Decision:** Python job execution runs in dedicated Python microservices (`py-job-executer`, `py-job-sagemaker-executer`, etc.), not inside the JVM.  
+**Reason:** Python ML libraries (PyTorch, TensorFlow, scikit-learn) cannot run inside a Java process. Separate executors also isolate memory and crash domains — a runaway Python job cannot take down the Java backend.

--- a/sv/docs/SCOPE.md
+++ b/sv/docs/SCOPE.md
@@ -1,0 +1,30 @@
+# Backend Services — Scope
+
+## Objective
+
+Provide a **Java 21 / Spring Boot 3.x microservices backend** that exposes RESTful APIs for the Essedum platform, covering user security, AI/ML pipeline execution, data connectivity, and AI-assisted coding. All external traffic enters through a single API Gateway and is routed to one of four domain services.
+
+---
+
+## Services at a Glance
+
+| Service | Domain | Description |
+|---|---|---|
+| [API Gateway](../api-gateway/docs/SCOPE.md) | Routing & Security | Single entry point for all traffic. Validates tokens, routes by URL path, applies rate limiting, and forwards correlation headers. No business logic. |
+| [USM Service](../usm-service/docs/SCOPE.md) | User & Access Management | Manages users, roles, organisations, and permissions. Issues and validates JWTs. Enforces RBAC on every request. |
+| [ICIP Service](../icip-service/docs/SCOPE.md) | AI/ML Pipelines & Jobs | Core execution engine. Runs training, inference, and RAG pipelines; manages the model registry; submits jobs to cloud ML platforms; streams job status in real time. |
+| [Data Service](../data-service/docs/SCOPE.md) | Files, Datasets & Adapters | Handles all data at rest and in motion — file storage, dataset management, schema registry, and pluggable adapters to external databases and cloud storage. |
+| [Vibe Service](../vibe-service/docs/SCOPE.md) | AI-Assisted Coding | Relays coding requests to the Goose AI engine via SSE, manages coding sessions and recipes, and syncs generated code to GitHub. |
+| Eureka | Service Discovery | Registry where all services self-register. Gateway resolves addresses dynamically — no hardcoded service URLs. |
+
+---
+
+## Detailed Scope
+
+Each service maintains its own scope document covering functional and non-functional requirements:
+
+- [API Gateway — SCOPE.md](../api-gateway/docs/SCOPE.md)
+- [USM Service — SCOPE.md](../usm-service/docs/SCOPE.md)
+- [ICIP Service — SCOPE.md](../icip-service/docs/SCOPE.md)
+- [Data Service — SCOPE.md](../data-service/docs/SCOPE.md)
+- [Vibe Service — SCOPE.md](../vibe-service/docs/SCOPE.md)

--- a/sv/icip-service/docs/ARCHITECTURE.md
+++ b/sv/icip-service/docs/ARCHITECTURE.md
@@ -1,0 +1,165 @@
+# ICIP Service — Architecture
+
+---
+
+## 1. Service Architecture
+
+ICIP is the most complex service. It combines a standard REST layer with an **asynchronous job execution engine**, a **scheduler**, and **real-time streaming**. Jobs submitted via REST are handed off to an execution subsystem; the REST call returns immediately while execution proceeds asynchronously.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        GW["API Gateway"]
+        WS["WebSocket clients\n(job status)"]
+    end
+
+    subgraph ICIP Service
+        CTL["REST Controllers\nPipelines · Jobs · Models · Agents · Events · MLOps"]
+        SVC["Service Layer\nOrchestration · Scheduling · Code Gen · Model Registry"]
+        EXEC["Job Execution Engine\nLocal executor dispatch · Cloud job submission"]
+        SCHED["Quartz Scheduler\nPersistent · Clustered"]
+        EVT["Event Manager\nEvent-to-job mapping · Webhook triggers"]
+        STREAM["WebSocket / SSE Handler\nReal-time status push"]
+        SEARCH["Lucene Search\nContent indexing"]
+        PLUGIN["Plugin System\nExtensible job types"]
+    end
+
+    subgraph External
+        DB_MAIN[("MySQL\nessedum_core")]
+        DB_QUARTZ[("MySQL\nQuartz DB")]
+        DB_MODEL[("MySQL\nModel DB")]
+        KAFKA["Kafka"]
+        RABBIT["RabbitMQ"]
+        SAGE["AWS SageMaker"]
+        VERTEX["GCP Vertex AI"]
+        AZML["Azure ML"]
+        LLM["LLM APIs\nOpenAI · Bedrock · Gemini"]
+        PY_EXEC["Python Executors\n(separate processes)"]
+    end
+
+    GW --> CTL --> SVC
+    WS --> STREAM
+    SVC --> EXEC
+    SVC --> SCHED --> DB_QUARTZ
+    SVC --> EVT
+    SVC --> SEARCH
+    EXEC --> PY_EXEC
+    EXEC --> SAGE
+    EXEC --> VERTEX
+    EXEC --> AZML
+    EXEC --> STREAM
+    EVT --> KAFKA
+    EVT --> RABBIT
+    SVC --> LLM
+    SVC --> DB_MAIN
+    SVC --> DB_MODEL
+    PLUGIN -.->|extends| EXEC
+```
+
+**Key internal subsystems:**
+- **Job Execution Engine** — dispatches jobs to the correct executor (local Python process or cloud ML platform). Tracks state transitions (queued → running → completed/failed).
+- **Quartz Scheduler** — manages timed and recurring job triggers using a clustered, database-backed store.
+- **Event Manager** — maps platform events (e.g., file uploaded, dataset updated) to job triggers.
+- **WebSocket Handler** — maintains open connections to UI clients and pushes state changes the moment they occur.
+- **Plugin System** — allows new job types to be registered without modifying core execution logic.
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| MySQL (`essedum_core`) | Internal DB | Pipelines, jobs, events, agents, plugins, execution history |
+| MySQL (Quartz DB) | Internal DB | Quartz job scheduler state — triggers, misfire records |
+| MySQL (Model DB) | Internal DB | Model registry, model versions, deployed endpoints |
+| Python Executors | Internal services | Run the actual Python pipeline code in isolated processes |
+| AWS SageMaker | External (HTTP) | Submit and monitor cloud training/inference jobs |
+| GCP Vertex AI | External (HTTP) | Submit and monitor cloud training/inference jobs |
+| Azure ML | External (HTTP) | Submit and monitor cloud training/inference jobs |
+| LLM APIs (OpenAI, Bedrock, Gemini) | External (HTTP) | AI code generation |
+| Kafka | Messaging | Publish job lifecycle events; consume stream inputs |
+| RabbitMQ | Messaging | Publish job lifecycle events; consume stream inputs |
+
+ICIP has **no dependency on USM, Data, or Vibe services** at runtime.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-ICIP1 — Asynchronous job execution via task queue
+Job submission returns immediately (HTTP 202). Execution happens asynchronously. The client tracks progress via WebSocket. This prevents HTTP timeouts on long-running ML jobs (which can run for hours) and decouples submission from execution throughput.
+
+### AD-ICIP2 — Quartz with a clustered database-backed store
+Quartz is configured with a JDBC job store (not in-memory). Scheduled triggers survive pod restarts and are not duplicated when multiple instances run. This is critical for exactly-once scheduled execution in Kubernetes where pods can be evicted at any time.
+
+### AD-ICIP3 — Python execution in separate processes, not the JVM
+Python ML libraries (PyTorch, scikit-learn, etc.) cannot run inside a Java process. Python executors are separate microservices. ICIP communicates with them over HTTP. A runaway Python job cannot consume the Java heap or crash the ICIP service.
+
+### AD-ICIP4 — Plugin system for extensible job types
+New job types (e.g., a new ML framework or data processing step) are added as plugins that implement a standard interface. Core execution logic does not change. This keeps the service open for extension without modifying tested code paths.
+
+### AD-ICIP5 — Events published to message queues, not direct service calls
+When a job completes or fails, ICIP publishes an event to Kafka / RabbitMQ. Downstream consumers (e.g., notification service, audit log) subscribe independently. ICIP does not know or care who is listening. This avoids tight coupling to consumers that may not exist yet.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Pipeline Execution (On-Demand)
+
+```mermaid
+sequenceDiagram
+    participant U as User (UI)
+    participant GW as API Gateway
+    participant ICIP as ICIP Service
+    participant PY as Python Executor
+    participant WS as WebSocket
+
+    U->>GW: POST /api/icip/jobs/run {pipelineId}
+    GW->>ICIP: Forward
+    ICIP->>ICIP: Validate pipeline + resolve execution container
+    ICIP->>ICIP: Persist job record (status=QUEUED)
+    ICIP-->>U: 202 Accepted {jobId}
+    ICIP->>PY: Submit job payload (async)
+    PY-->>ICIP: Job started (status=RUNNING)
+    ICIP->>WS: Push status update to connected UI clients
+    PY-->>ICIP: Streaming log lines
+    ICIP->>WS: Stream logs to UI
+    PY-->>ICIP: Job finished (status=COMPLETED, artifacts)
+    ICIP->>ICIP: Persist result + register model (if training)
+    ICIP->>WS: Push COMPLETED status to UI
+```
+
+### Flow 2 — Scheduled Job Trigger
+
+```mermaid
+sequenceDiagram
+    participant QUARTZ as Quartz Scheduler
+    participant ICIP as ICIP Service
+    participant PY as Python Executor
+
+    QUARTZ->>ICIP: Trigger fires (cron expression matched)
+    ICIP->>ICIP: Load pipeline definition from DB
+    ICIP->>ICIP: Create job record (status=QUEUED)
+    ICIP->>PY: Submit job
+    Note over ICIP: Same execution path as on-demand
+```
+
+### Flow 3 — Cloud ML Job Submission (SageMaker)
+
+```mermaid
+sequenceDiagram
+    participant ICIP as ICIP Service
+    participant VAULT as Vault
+    participant SAGE as AWS SageMaker
+
+    ICIP->>VAULT: Fetch AWS credentials for execution container
+    VAULT-->>ICIP: AccessKeyId + SecretAccessKey
+    ICIP->>SAGE: CreateTrainingJob (script, instance type, S3 input/output)
+    SAGE-->>ICIP: Job ARN
+    loop Poll until terminal state
+        ICIP->>SAGE: DescribeTrainingJob (ARN)
+        SAGE-->>ICIP: Status (InProgress / Completed / Failed)
+        ICIP->>ICIP: Update job record + push WebSocket update
+    end
+```

--- a/sv/icip-service/docs/SCOPE.md
+++ b/sv/icip-service/docs/SCOPE.md
@@ -1,0 +1,70 @@
+# ICIP Service — Scope
+
+## Objective
+
+Serve as the **AI/ML execution engine** of the platform. Accept pipeline and job definitions from users, orchestrate their execution on local or cloud ML infrastructure, manage the model registry, and stream real-time results back to the UI.
+
+---
+
+## Functional Requirements
+
+### Pipeline & Job Management
+
+| ID | Requirement |
+|---|---|
+| FR-ICIP1 | Users can create AI/ML pipelines by providing Python code. Three pipeline types are supported: Training, Inference, and RAG (Retrieval-Augmented Generation). |
+| FR-ICIP2 | Pipelines can be run on-demand or scheduled at a fixed time or recurring interval. |
+| FR-ICIP3 | Jobs can be triggered automatically when a defined platform event occurs (event-driven execution). |
+| FR-ICIP4 | Job execution status is pushed to the UI in real time via WebSocket. Users never need to poll. |
+| FR-ICIP5 | Users can view the full execution log, elapsed time, and error details for any job run. |
+| FR-ICIP6 | Failed jobs are retried automatically up to a configurable limit before being marked as permanently failed. |
+| FR-ICIP7 | Pipelines can be cloned, versioned, and shared within a project. |
+| FR-ICIP8 | Jobs can be cancelled mid-execution. The service cleans up any in-progress cloud resources on cancellation. |
+
+### Cloud ML Execution
+
+| ID | Requirement |
+|---|---|
+| FR-ICIP9 | Pipelines can be submitted to **AWS SageMaker**, **GCP Vertex AI**, or **Azure ML** using the credentials stored in the linked execution container. |
+| FR-ICIP10 | The service supports local Python execution for development and testing without cloud infrastructure. |
+| FR-ICIP11 | The service monitors submitted cloud jobs and reflects their status back to the platform in real time. |
+
+### Model Registry
+
+| ID | Requirement |
+|---|---|
+| FR-ICIP12 | Models produced by a successful training run are automatically registered in the model registry. |
+| FR-ICIP13 | Users can upload pre-trained models manually and register them with metadata (framework, version, description). |
+| FR-ICIP14 | Registered models can be deployed as inference endpoints on SageMaker, Vertex AI, or Azure ML directly from the UI. |
+| FR-ICIP15 | Deployed endpoint status (running, stopped, error) is visible in the UI. Users can invoke an endpoint with a sample payload to validate it. |
+
+### AI Agents & Code Generation
+
+| ID | Requirement |
+|---|---|
+| FR-ICIP16 | Users can define and execute AI agent jobs (LangChain, HayStack, drag-and-drop agent canvas). |
+| FR-ICIP17 | The service generates Python code on demand using Azure OpenAI, AWS Bedrock, or GCP Vertex AI (Gemini). |
+| FR-ICIP18 | Agent definitions are stored and versioned in the agent directory for reuse across projects. |
+
+### Streaming & Events
+
+| ID | Requirement |
+|---|---|
+| FR-ICIP19 | The service publishes job lifecycle events (started, completed, failed) to Kafka and RabbitMQ for downstream consumers. |
+| FR-ICIP20 | The service can consume and process streaming data from Kafka and RabbitMQ topics as pipeline inputs. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-ICIP1 | Job submission must respond in **< 500 ms**. Actual execution time depends on the workload and cloud platform. |
+| NFR-ICIP2 | WebSocket job status updates must reach the UI within **2 seconds** of a state change in the executor. |
+| NFR-ICIP3 | The service must support **concurrent execution of multiple jobs** across multiple service instances without job state collisions. |
+| NFR-ICIP4 | The Quartz job scheduler must use a **persistent, database-backed, clustered store**. Scheduled jobs must survive a pod restart without loss. |
+| NFR-ICIP5 | The service must scale horizontally. Each instance is stateless; job state is stored in the database. |
+| NFR-ICIP6 | Total database connection pool must not exceed **46 connections** (30 main + 8 Quartz + 8 model DB). |
+| NFR-ICIP7 | Cloud ML credentials must never be logged. They are retrieved at runtime from the secrets manager. |
+| NFR-ICIP8 | The service exposes `/actuator/health` for Kubernetes liveness and readiness probes. |
+| NFR-ICIP9 | Job execution history must be retained for a minimum of **90 days** before archival. |

--- a/sv/usm-service/docs/ARCHITECTURE.md
+++ b/sv/usm-service/docs/ARCHITECTURE.md
@@ -1,0 +1,141 @@
+# USM Service — Architecture
+
+---
+
+## 1. Service Architecture
+
+USM is a **standard layered Spring Boot service**. Requests arrive from the gateway, pass through security filters, reach a REST controller, and flow down through the service and repository layers to the database.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        GW["API Gateway"]
+    end
+
+    subgraph USM Service
+        SEC["Security Filter\nRBAC permission check"]
+        CTL["REST Controllers\nUsers · Roles · Orgs · Auth · Notifications"]
+        SVC["Service Layer\nBusiness logic · Token issuance · Delegation"]
+        REPO["Repository Layer\nSpring Data JPA"]
+        SEC_LIB["Shared Libs\ncomm-lib-util · common-lib-rest · comm-lib-secrets"]
+    end
+
+    subgraph External
+        DB[("MySQL\nessedum_usm")]
+        KC["Keycloak\nOAuth2 / OIDC"]
+        VAULT["HashiCorp Vault\n/ Azure Key Vault"]
+        EMAIL["Email Provider\nSMTP"]
+    end
+
+    GW --> SEC --> CTL --> SVC --> REPO --> DB
+    SVC --> KC
+    SVC --> VAULT
+    SVC --> EMAIL
+    SEC_LIB -.->|used by| SVC
+```
+
+**Layer responsibilities:**
+- **Security Filter** — verifies the JWT, resolves the user's roles, and checks permissions against the requested endpoint before the controller is reached.
+- **Controllers** — parse HTTP requests, validate inputs, delegate to services, return responses. No business logic.
+- **Service Layer** — owns all business rules: token issuance, RBAC evaluation, delegation logic, notification dispatch.
+- **Repository Layer** — JPA-based persistence. One repository per aggregate root (User, Role, Organisation, Project, etc.).
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| MySQL (`essedum_usm`) | Internal DB | Stores users, roles, permissions, organisations, projects, notifications |
+| Keycloak | External (HTTP) | OAuth2 / OIDC token exchange; federates external IdPs (LDAP, SAML) |
+| HashiCorp Vault / Azure KV | External (HTTP) | Read and write secrets (API keys, cloud credentials) |
+| Email Provider (SMTP) | External | Send password-reset and account-invite emails |
+| `comm-lib-util` | Shared library | Logging, common utilities |
+| `comm-lib-secrets` | Shared library | Vault / Key Vault client abstraction |
+| `common-lib-rest` | Shared library | Error response format, REST helpers |
+
+USM has **no dependency on any other domain service** (ICIP, Data, Vibe).
+
+---
+
+## 3. Architectural Decisions
+
+### AD-USM1 — RBAC enforced in the service layer, not just the UI
+Permission checks run server-side on every API call. The UI can hide buttons, but access is ultimately controlled by the server. This prevents privilege escalation via direct API calls.
+
+### AD-USM2 — JWT issued by USM, validated by the gateway
+USM mints tokens for DB-JWT auth mode. For OAuth2 mode, Keycloak mints the token and USM validates it. In both cases, the gateway is the single validation point — USM does not re-validate tokens arriving from the gateway.
+
+### AD-USM3 — Project as the isolation boundary
+All data in the platform (files, pipelines, models) is scoped to a project. USM owns the project definition and user-project-role assignment. Other services enforce the boundary by checking the project claim in the token.
+
+### AD-USM4 — Secrets stored in Vault, not the database
+Credentials and API keys referenced by users or pipelines are stored in Vault / Azure Key Vault. The database holds only a reference (path/key name). This ensures secrets are never exposed in a database dump.
+
+### AD-USM5 — Auth mode switchable via Spring profile
+The service supports `dbjwt` (self-issued JWT) and `oauth2` (Keycloak) auth modes, toggled by the active Spring profile. The same binary runs in both modes; no code branching.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — User Login (DB JWT mode)
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant GW as API Gateway
+    participant USM as USM Service
+    participant DB as MySQL
+
+    C->>GW: POST /api/authenticate {username, password}
+    GW->>USM: Forward (no token required for this endpoint)
+    USM->>DB: Load user record + hashed password
+    USM->>USM: Verify bcrypt hash
+    alt Invalid credentials
+        USM-->>C: 401 Unauthorized
+    else Valid
+        USM->>DB: Load roles + permissions for user
+        USM->>USM: Sign JWT with user claims + roles
+        USM-->>C: 200 OK {token, expiry}
+    end
+```
+
+### Flow 2 — Permission Check on Protected Endpoint
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant GW as API Gateway
+    participant USM as USM Service
+    participant DB as MySQL
+
+    C->>GW: GET /api/usm/roles (Bearer token)
+    GW->>GW: Validate token signature + expiry
+    GW->>USM: Forward request + user claims in headers
+    USM->>USM: Extract user ID + roles from token
+    USM->>DB: Load permission set for roles
+    alt Missing permission
+        USM-->>C: 403 Forbidden
+    else Permitted
+        USM->>DB: Fetch roles
+        USM-->>C: 200 OK [roles]
+    end
+```
+
+### Flow 3 — User-Project-Role Assignment
+
+```mermaid
+sequenceDiagram
+    participant ADMIN as Admin User
+    participant GW as API Gateway
+    participant USM as USM Service
+    participant DB as MySQL
+
+    ADMIN->>GW: POST /api/usm/user-project-roles {userId, projectId, roleId}
+    GW->>USM: Forward
+    USM->>USM: Verify caller has ADMIN permission on the project
+    USM->>DB: Insert user_project_role record
+    USM-->>ADMIN: 201 Created
+    Note over USM: Next token issued to that user<br/>will include the new project + role claim
+```

--- a/sv/usm-service/docs/SCOPE.md
+++ b/sv/usm-service/docs/SCOPE.md
@@ -1,0 +1,67 @@
+# USM Service — Scope
+
+## Objective
+
+Own the entire **identity, access, and organisational model** for the platform. Every user, role, permission, organisation, and project is defined here. All other services rely on USM-issued tokens and USM-defined permissions to make authorisation decisions.
+
+---
+
+## Functional Requirements
+
+### Authentication
+
+| ID | Requirement |
+|---|---|
+| FR-USM1 | Users can authenticate with username + password. The service issues a signed JWT on success. |
+| FR-USM2 | The service supports OAuth2 / OIDC login via Keycloak. External identity providers (LDAP, SAML) can be federated through Keycloak. |
+| FR-USM3 | Tokens have a configurable expiry. Expired tokens are rejected with HTTP 401. |
+| FR-USM4 | Users can reset their password via a time-limited email link. |
+
+### User Management
+
+| ID | Requirement |
+|---|---|
+| FR-USM5 | Administrators can create, update, and deactivate user accounts. |
+| FR-USM6 | Each user has a profile (name, email, timezone, notification preferences). |
+| FR-USM7 | Administrators can assign users to projects and define their role within each project. |
+| FR-USM8 | One user can delegate access to another user for a defined period. |
+
+### Role & Permission Management
+
+| ID | Requirement |
+|---|---|
+| FR-USM9 | Roles are created and managed by administrators. Each role has a named set of permissions. |
+| FR-USM10 | Permissions are defined at the module level and at the individual API endpoint level. |
+| FR-USM11 | Every API call is checked against the calling user's permissions. Unauthorised calls return HTTP 403. |
+| FR-USM12 | Role-to-role mappings allow hierarchical permission inheritance. |
+
+### Organisation & Project Management
+
+| ID | Requirement |
+|---|---|
+| FR-USM13 | The system supports a three-level hierarchy: Organisation → Org Unit → Portfolio → Project. |
+| FR-USM14 | Projects are isolated boundaries — users cannot access data, pipelines, or models outside their assigned projects. |
+| FR-USM15 | Administrators can create, update, and archive organisations, org units, and projects. |
+
+### Secrets & Notifications
+
+| ID | Requirement |
+|---|---|
+| FR-USM16 | Sensitive credentials (API keys, cloud secrets) are stored and retrieved via HashiCorp Vault or Azure Key Vault — never in the database as plaintext. |
+| FR-USM17 | Users receive in-app notifications for key events. Notification preferences are configurable per user. |
+| FR-USM18 | The service can send transactional emails (password reset, account invite). |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-USM1 | Authentication endpoint (`/api/authenticate`) must respond in **< 300 ms** at 100 concurrent users. |
+| NFR-USM2 | All user passwords must be hashed with a strong algorithm (bcrypt or Argon2). Plaintext passwords must never be logged or stored. |
+| NFR-USM3 | The service must support **at least 500 concurrent authenticated sessions** without degradation. |
+| NFR-USM4 | The service is stateless — token validation requires no shared in-process state, enabling horizontal scaling. |
+| NFR-USM5 | Database connection pool is capped at **20 connections** to prevent MySQL exhaustion. |
+| NFR-USM6 | All secrets are injected via environment variables or Vault. No credential is hardcoded in source or config files. |
+| NFR-USM7 | The service exposes `/actuator/health` for Kubernetes liveness and readiness probes. |
+| NFR-USM8 | Audit events (login, logout, role change, user deactivation) must be logged with a timestamp and actor identity. |

--- a/sv/vibe-service/docs/ARCHITECTURE.md
+++ b/sv/vibe-service/docs/ARCHITECTURE.md
@@ -1,0 +1,146 @@
+# Vibe Service — Architecture
+
+---
+
+## 1. Service Architecture
+
+Vibe Service is a **relay and session manager**. It does not generate code itself — it forwards requests to the Goose AI engine and streams the response back to the UI via SSE. All state (sessions, recipes, schedules) is persisted in its own database so any service instance can serve any session.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        GW["API Gateway"]
+        SSE_CLIENT["Browser (SSE connection)"]
+    end
+
+    subgraph Vibe Service
+        CTL["REST Controllers\nCoding · Sessions · Recipes · Schedules · GitHub · OAuth"]
+        SVC["Service Layer\nSession management · Recipe resolution · GitHub sync · Schedule mgmt"]
+        SSE_HANDLER["SSE Handler\nStream AI tokens to UI as they arrive"]
+        GOOSE_CLIENT["Goose API Client\nHTTP relay to Goose AI engine"]
+        GH_CLIENT["GitHub Client\nOAuth + REST API"]
+        SCHED["Scheduler\nRecurring coding tasks"]
+    end
+
+    subgraph External
+        DB[("MySQL\nessedum_vibe")]
+        GOOSE["Goose AI Engine\n(external process / pod)"]
+        GITHUB["GitHub API"]
+        VAULT["Vault / Azure KV\n(OAuth token storage)"]
+    end
+
+    GW --> CTL --> SVC
+    SSE_CLIENT --> SSE_HANDLER
+    SVC --> GOOSE_CLIENT --> GOOSE
+    GOOSE_CLIENT --> SSE_HANDLER
+    SVC --> GH_CLIENT --> GITHUB
+    SVC --> SCHED
+    SVC --> DB
+    GH_CLIENT --> VAULT
+```
+
+**Key internal subsystems:**
+- **SSE Handler** — holds open HTTP connections to browser clients. As Goose AI streams tokens, the handler pushes each chunk to the correct client connection identified by session ID.
+- **Goose API Client** — wraps the HTTP call to the Goose AI engine. It reads the streaming response and feeds chunks to the SSE handler in real time.
+- **GitHub Client** — handles OAuth token exchange and all GitHub REST operations (push, PR creation, branch listing).
+- **Scheduler** — triggers recurring coding tasks using a lightweight internal scheduler backed by the `essedum_vibe` database.
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| MySQL (`essedum_vibe`) | Internal DB | Sessions, recipes, schedules, system config, GitHub OAuth token references |
+| Goose AI Engine | External (HTTP/Stream) | Receives coding prompts; streams back generated code and explanations |
+| GitHub API | External (HTTP) | Push code, create branches, open pull requests, list repos |
+| Vault / Azure Key Vault | External (HTTP) | Store and retrieve GitHub OAuth access tokens |
+
+Vibe Service has **no dependency on USM, ICIP, or Data services** at runtime.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-VIBE1 — Vibe is a relay, not a code generator
+Vibe does not embed an LLM or run inference. It proxies requests to the Goose AI engine. This separation keeps Vibe lightweight and means the AI model can be upgraded or swapped (different Goose version, different engine) without changing the Vibe service.
+
+### AD-VIBE2 — SSE for streaming over WebSocket
+SSE (Server-Sent Events) is used instead of WebSocket for streaming AI responses. SSE is unidirectional (server → client), works over standard HTTP, and does not require a persistent bidirectional socket. For the use case of streaming text tokens, SSE is simpler and equally effective.
+
+### AD-VIBE3 — Sessions are stateless across instances
+Session state (conversation history, status) is persisted in MySQL. Any Vibe instance can resume any session. The SSE connection is the only in-memory state, and it re-attaches to the session record on reconnect.
+
+### AD-VIBE4 — GitHub OAuth tokens stored in Vault, not in MySQL
+After the OAuth callback, the GitHub access token is written to Vault. MySQL stores only the Vault path. This prevents token exposure in a database dump and centralises token lifecycle management.
+
+### AD-VIBE5 — One OAuth token per user, not a shared platform credential
+Each user connects their own GitHub account. Vibe uses the per-user token for all GitHub operations on their behalf. The platform never has a shared GitHub token, eliminating the risk of one user's action affecting another's repositories.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — AI Coding Request with SSE Streaming
+
+```mermaid
+sequenceDiagram
+    participant U as User (Browser)
+    participant GW as API Gateway
+    participant VIBE as Vibe Service
+    participant GOOSE as Goose AI Engine
+    participant DB as MySQL
+
+    U->>GW: POST /api/vibe/coding/run {sessionId, prompt}
+    GW->>VIBE: Forward
+    VIBE->>DB: Load session + recipe context
+    VIBE->>GOOSE: POST /run {prompt + context} (streaming response)
+    VIBE-->>U: 200 OK (SSE stream opens)
+    loop Token by token
+        GOOSE-->>VIBE: Next token chunk
+        VIBE-->>U: SSE event: data={chunk}
+    end
+    GOOSE-->>VIBE: Stream complete
+    VIBE->>DB: Persist full response to session history
+    VIBE-->>U: SSE event: data=[DONE]
+```
+
+### Flow 2 — Push Generated Code to GitHub
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant VIBE as Vibe Service
+    participant VAULT as Vault
+    participant GH as GitHub API
+
+    U->>VIBE: POST /api/vibe/github/push {sessionId, repo, branch, message}
+    VIBE->>VAULT: Fetch GitHub OAuth token for user
+    VAULT-->>VIBE: access_token
+    VIBE->>GH: Get current file SHA (if file exists)
+    GH-->>VIBE: SHA or 404
+    VIBE->>GH: PUT /repos/{owner}/{repo}/contents/{path} {content, message, branch, sha?}
+    GH-->>VIBE: 201 Created / 200 Updated
+    VIBE-->>U: 200 OK {commitUrl}
+```
+
+### Flow 3 — GitHub OAuth Authorisation Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User (Browser)
+    participant VIBE as Vibe Service
+    participant GH as GitHub OAuth
+    participant VAULT as Vault
+    participant DB as MySQL
+
+    U->>VIBE: GET /api/vibe/github/auth/initiate
+    VIBE-->>U: Redirect to GitHub OAuth consent page
+    U->>GH: User grants access
+    GH-->>VIBE: GET /api/vibe/github/auth/callback?code=xxx
+    VIBE->>GH: POST /login/oauth/access_token {code, client_id, secret}
+    GH-->>VIBE: access_token
+    VIBE->>VAULT: Store access_token under user path
+    VIBE->>DB: Record vault path for user's GitHub token
+    VIBE-->>U: Redirect to UI (auth complete)
+```

--- a/sv/vibe-service/docs/SCOPE.md
+++ b/sv/vibe-service/docs/SCOPE.md
@@ -1,0 +1,56 @@
+# Vibe Service — Scope
+
+## Objective
+
+Provide **AI-assisted coding** capabilities by acting as a relay between the platform and the Goose AI engine. Manage coding sessions, stream AI responses in real time, and synchronise generated code with GitHub repositories.
+
+---
+
+## Functional Requirements
+
+### AI Coding Sessions
+
+| ID | Requirement |
+|---|---|
+| FR-VIBE1 | Users can start a new AI coding session with a natural-language task description. |
+| FR-VIBE2 | The service relays the coding request to the Goose AI engine and streams the response back to the UI via Server-Sent Events (SSE). The user sees output as it is generated — no waiting for a complete response. |
+| FR-VIBE3 | Sessions are persisted. Users can resume a previous session and view the full conversation history. |
+| FR-VIBE4 | Users can cancel an in-progress coding session. The service terminates the upstream Goose request and updates the session status. |
+
+### Recipes
+
+| ID | Requirement |
+|---|---|
+| FR-VIBE5 | Users can create and manage Goose AI recipes — reusable task templates that pre-fill the coding prompt for common workflows. |
+| FR-VIBE6 | Recipes can be scoped to a project or shared across the organisation. |
+
+### GitHub Integration
+
+| ID | Requirement |
+|---|---|
+| FR-VIBE7 | Users can connect their GitHub account via OAuth. The service stores the OAuth token for subsequent operations. |
+| FR-VIBE8 | Generated code can be pushed to a specified GitHub repository and branch directly from the UI. |
+| FR-VIBE9 | The service can open a pull request on GitHub for the pushed code, with an AI-generated description. |
+| FR-VIBE10 | Users can browse available repositories and branches within their connected GitHub account. |
+
+### Scheduling & Configuration
+
+| ID | Requirement |
+|---|---|
+| FR-VIBE11 | Users can schedule a recurring AI coding task (e.g., a nightly code review or refactor job). |
+| FR-VIBE12 | Administrators can configure Goose AI system settings (model selection, temperature, tool permissions) per deployment. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-VIBE1 | First token of the AI response must reach the UI via SSE within **3 seconds** of the user submitting a request (network latency to the Goose AI engine excluded). |
+| NFR-VIBE2 | The service must support **multiple concurrent coding sessions** without responses from one session leaking into another. |
+| NFR-VIBE3 | GitHub OAuth tokens are stored encrypted and never returned in API responses or logs. |
+| NFR-VIBE4 | A failure in the Goose AI engine must not crash the service. The service returns a clear error to the client and marks the session as failed. |
+| NFR-VIBE5 | The service is stateless between requests. Session state is persisted in the database, allowing any instance to serve any session. |
+| NFR-VIBE6 | Database connection pool is capped at **15 connections**. |
+| NFR-VIBE7 | The service exposes `/actuator/health` for Kubernetes liveness and readiness probes. |
+| NFR-VIBE8 | All GitHub API calls must use the user's own OAuth token. The service must never use a shared platform-level GitHub credential for user-initiated operations. |

--- a/vibe-code-builder-deployer/docs/ARCHITECTURE.md
+++ b/vibe-code-builder-deployer/docs/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# Vibe Code Builder Deployer — Architecture
+
+---
+
+## 1. Service Architecture
+
+Identical in pattern to the ADK Code Builder Deployer — Flask + Socket.IO with a long-running pipeline handler. The key differences: Kubernetes-only (no Docker mode), uses a ClusterIP registry URL configured for containerd compatibility, and targets Vibe coding session workloads.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        UI["Vibe UI\n(Socket.IO client)"]
+    end
+
+    subgraph Vibe Code Builder Deployer
+        REST["REST API\n/api/delete-deployment\n/api/list-deployments · /health"]
+        SIO["Socket.IO\nstart_pipeline · delete_deployment\nconnect · disconnect"]
+        PIPELINE["Build & Deploy Pipeline\n1. Download source (S3/MinIO)\n2. Extract archive\n3. buildctl image build\n4. Push to registry\n5. K8s Deployment + Service + Secret"]
+        LOG["Event Broadcaster\npipeline_update events → client"]
+    end
+
+    subgraph Infrastructure
+        K8S["Kubernetes API\nDeployments · Services · Secrets"]
+        BUILDKIT["BuildKit daemon\ntcp://buildkitd:1234"]
+        REGISTRY["In-Cluster Registry\nClusterIP :5000"]
+        S3["AWS S3 / MinIO\nSource code archives"]
+    end
+
+    UI -->|Socket.IO| SIO
+    UI -->|HTTP| REST
+    SIO --> PIPELINE
+    PIPELINE --> S3 & BUILDKIT & K8S
+    BUILDKIT --> REGISTRY
+    PIPELINE --> LOG --> UI
+    REST --> K8S
+```
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Kubernetes API | Internal (in-cluster) | Create/delete Deployments, Services, Secrets |
+| BuildKit daemon | Internal (TCP) | Build container images from source |
+| In-cluster registry (ClusterIP) | Internal (HTTP) | Store and serve built images |
+| AWS S3 / MinIO | External (HTTP/SDK) | Download Vibe agent source code archives |
+
+---
+
+## 3. Architectural Decisions
+
+### AD-VCB1 — ClusterIP registry for containerd compatibility
+**Decision:** The in-cluster registry is addressed by its ClusterIP (e.g., `10.104.220.183:5000`) rather than a DNS service name.
+**Reason:** containerd, used as the Kubernetes container runtime, requires the registry URL to match exactly what is configured in its `registries.conf`. ClusterIP is stable and avoids containerd's DNS resolution timing issues during image pull at pod startup.
+
+### AD-VCB2 — Kubernetes-only (no Docker mode)
+**Decision:** Unlike the ADK deployer, this service has no Docker fallback mode.
+**Reason:** Vibe coding sessions are always deployed to Kubernetes. The Docker mode complexity is not needed, and removing it reduces the code surface and eliminates a potential configuration error path.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Build and Deploy Vibe Agent Container
+
+```mermaid
+sequenceDiagram
+    participant UI as Vibe UI (Socket.IO)
+    participant SVC as Vibe Deployer
+    participant S3 as S3 / MinIO
+    participant BK as BuildKit
+    participant REG as In-Cluster Registry
+    participant K8S as Kubernetes
+
+    UI->>SVC: emit start_pipeline {source_url, agent_config}
+    SVC->>UI: pipeline_update {step: "downloading"}
+    SVC->>S3: Download source archive
+    SVC->>UI: pipeline_update {step: "building"}
+    SVC->>BK: buildctl build --output image:registry/vibe-agent:tag
+    BK->>REG: Push image
+    SVC->>UI: pipeline_update {step: "deploying"}
+    SVC->>K8S: Create Secret
+    SVC->>K8S: Create Deployment
+    SVC->>K8S: Create Service
+    SVC->>UI: pipeline_update {step: "done", status: "SUCCESS"}
+```

--- a/vibe-code-builder-deployer/docs/SCOPE.md
+++ b/vibe-code-builder-deployer/docs/SCOPE.md
@@ -1,0 +1,46 @@
+# Vibe Code Builder Deployer — Scope
+
+## Objective
+
+Build container images for Vibe coding session agents and deploy them as running Kubernetes services. The service receives a build-and-deploy request via Socket.IO, downloads source code from S3/MinIO, invokes BuildKit to produce a container image, pushes it to an in-cluster registry, and creates a Kubernetes Deployment and Service — streaming real-time build progress back to the caller. It is the Vibe-specific counterpart to the ADK Code Builder Deployer and targets the Vibe platform exclusively (Kubernetes-only, no Docker mode).
+
+---
+
+## Functional Requirements
+
+### Deployment Management
+
+| ID | Requirement |
+|---|---|
+| FR-VCB1 | The service accepts a delete-deployment request via `POST /api/delete-deployment` or the `delete_deployment` Socket.IO event, removing the Kubernetes Deployment, Service, and associated Secrets. |
+| FR-VCB2 | The service lists active deployments in the target namespace via `GET /api/list-deployments`. |
+| FR-VCB3 | Deployment names are sanitized to valid Kubernetes DNS-label format before any K8s API call. |
+
+### Build and Deploy Pipeline (Socket.IO)
+
+| ID | Requirement |
+|---|---|
+| FR-VCB4 | Clients connect via Socket.IO and trigger a build+deploy pipeline by emitting the `start_pipeline` event. |
+| FR-VCB5 | The service downloads the Vibe agent source code archive from S3 or MinIO. |
+| FR-VCB6 | The service invokes BuildKit (`buildctl`) to build a container image, streaming build output to the client via `pipeline_update` events. |
+| FR-VCB7 | The built image is pushed to the configured in-cluster container registry. |
+| FR-VCB8 | The service creates a Kubernetes Deployment and Service for the Vibe agent, injecting required secrets as environment variables. |
+| FR-VCB9 | Each pipeline step emits a timestamped `pipeline_update` Socket.IO event to the connected client. |
+
+### Health
+
+| ID | Requirement |
+|---|---|
+| FR-VCB10 | A health check endpoint is available at `GET /health`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-VCB1 | Socket.IO ping timeout is **300 seconds** to accommodate long container builds. |
+| NFR-VCB2 | Maximum Socket.IO HTTP buffer size is **10 MB** for large build payloads. |
+| NFR-VCB3 | The service operates in **Kubernetes mode only** — no Docker fallback. |
+| NFR-VCB4 | Registry URL is configurable via `REGISTRY_URL` environment variable. BuildKit address via `BUILDKIT_ADDR`. |
+| NFR-VCB5 | Deployment names are sanitized with regex before any Kubernetes API call. |

--- a/vibe-pod-watcher/docs/ARCHITECTURE.md
+++ b/vibe-pod-watcher/docs/ARCHITECTURE.md
@@ -1,0 +1,101 @@
+# Vibe Pod Watcher — Architecture
+
+---
+
+## 1. Service Architecture
+
+A Flask + Socket.IO service that bridges the Kubernetes API to the Vibe UI. REST endpoints call the K8s API synchronously; log streaming uses a dedicated background thread per Socket.IO connection to tail pod logs and push lines as events.
+
+```mermaid
+graph TB
+    subgraph Inbound
+        UI["Vibe UI\n(REST + Socket.IO)"]
+    end
+
+    subgraph Vibe Pod Watcher
+        REST["REST API\n/health · /api/namespaces · /api/pods\n/api/deployments · /api/pipeline-pods/*"]
+        SIO["Socket.IO\nstream_logs · stop_log_stream · disconnect"]
+        LOG_THREAD["Per-Client Log Thread\nK8s log_stream → socket emit\nStop flag per sid"]
+        K8S_CLIENT["Kubernetes Client\nCoreV1Api · AppsV1Api\nIn-cluster or kubeconfig"]
+    end
+
+    subgraph Kubernetes
+        PODS["Pods\nvibe-apps · vibe-mcp · vibe-agents"]
+        DEPLOYS["Deployments"]
+        SECRETS["Secrets"]
+        SVCS["Services"]
+    end
+
+    UI -->|HTTP| REST
+    UI -->|Socket.IO| SIO
+    REST --> K8S_CLIENT
+    SIO --> LOG_THREAD
+    LOG_THREAD --> K8S_CLIENT
+    K8S_CLIENT --> PODS & DEPLOYS & SECRETS & SVCS
+    LOG_THREAD -->|log_line events| UI
+```
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Kubernetes API (`kubernetes` SDK) | Internal (in-cluster) | List/get/delete pods and deployments, stream pod logs |
+| Kubernetes namespaces (`vibe-apps`, `vibe-mcp`, `vibe-agents`) | Internal | Target namespaces for all K8s operations |
+
+No external services or databases. All state is read from the Kubernetes API.
+
+---
+
+## 3. Architectural Decisions
+
+### AD-VPW1 — Per-client log streaming thread with stop flag
+**Decision:** Each Socket.IO client that subscribes to pod logs gets a dedicated background thread. A `threading.Event` stop flag is keyed by `socket.sid` and signals the thread to exit when the client disconnects or emits `stop_log_stream`.
+**Reason:** The Kubernetes Python SDK's `log_stream` is a blocking iterator. Running it in a background thread prevents it from blocking the event loop. The per-sid stop flag ensures clean thread shutdown without joining threads on every frame.
+
+### AD-VPW2 — In-cluster config with kubeconfig fallback
+**Decision:** The service calls `load_incluster_config()` at startup; if it fails (i.e., running outside a cluster), it falls back to `load_kube_config()`.
+**Reason:** In production the service runs as a Kubernetes pod with a mounted ServiceAccount token. The fallback supports local development without changing any code or configuration.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — Real-Time Pod Log Streaming
+
+```mermaid
+sequenceDiagram
+    participant UI as Vibe UI (Socket.IO)
+    participant SVC as Pod Watcher
+    participant THREAD as Log Thread
+    participant K8S as Kubernetes API
+
+    UI->>SVC: emit stream_logs {pod_name, namespace}
+    SVC->>SVC: Create stop_event for sid
+    SVC->>THREAD: Start background thread
+    THREAD->>K8S: read_namespaced_pod_log (follow=True, stream=True)
+    loop Each log line
+        K8S-->>THREAD: log line
+        THREAD->>UI: emit log_line {pod_name, line}
+    end
+    UI->>SVC: emit stop_log_stream
+    SVC->>THREAD: stop_event.set()
+    THREAD->>THREAD: Exit loop
+```
+
+### Flow 2 — Deployment Deletion
+
+```mermaid
+sequenceDiagram
+    participant UI as Vibe UI
+    participant SVC as Pod Watcher
+    participant K8S as Kubernetes API
+
+    UI->>SVC: DELETE /api/deployments/{deployment_name}?namespace=vibe-apps
+    SVC->>K8S: delete_namespaced_deployment(name, namespace)
+    SVC->>K8S: delete_namespaced_service(name, namespace)
+    SVC->>K8S: delete_namespaced_secret(name, namespace)
+    K8S-->>SVC: 200 OK (each)
+    SVC-->>UI: 200 OK {deleted: [deployment, service, secret]}
+```

--- a/vibe-pod-watcher/docs/SCOPE.md
+++ b/vibe-pod-watcher/docs/SCOPE.md
@@ -1,0 +1,60 @@
+# Vibe Pod Watcher — Scope
+
+## Objective
+
+Provide a **Kubernetes pod monitoring and management API** for the Vibe coding platform. The service watches pods and deployments in the `vibe-apps`, `vibe-mcp`, and `vibe-agents` namespaces, streams live pod logs over Socket.IO, and exposes REST endpoints for listing, inspecting, and deleting pods and deployments. It is the observability and control plane for dynamically spawned Vibe coding session containers.
+
+---
+
+## Functional Requirements
+
+### Namespace & Pod Inspection
+
+| ID | Requirement |
+|---|---|
+| FR-VPW1 | The service returns the list of watched Kubernetes namespaces via `GET /api/namespaces`. |
+| FR-VPW2 | The service lists pods across all watched namespaces (or a specified namespace) via `GET /api/pods`, including pod name, status, namespace, node, IP, age, and container details. |
+| FR-VPW3 | The service retrieves recent log output from a specific pod via `GET /api/pods/{pod_name}/logs`. |
+
+### Deployment Inspection
+
+| ID | Requirement |
+|---|---|
+| FR-VPW4 | The service lists Kubernetes Deployments in the watched namespaces via `GET /api/deployments`, including replica counts and conditions. |
+
+### Pod & Deployment Deletion
+
+| ID | Requirement |
+|---|---|
+| FR-VPW5 | The service deletes a specific pod via `DELETE /api/pods/{pod_name}`. |
+| FR-VPW6 | The service deletes a Deployment and its associated Service and Secrets via `DELETE /api/deployments/{deployment_name}`. |
+
+### Real-Time Log Streaming
+
+| ID | Requirement |
+|---|---|
+| FR-VPW7 | Clients can subscribe to live log streaming for a specific pod by emitting the `stream_logs` Socket.IO event with `{pod_name, namespace}`. Log lines are pushed to the client as `log_line` events. |
+| FR-VPW8 | Log streaming for a specific pod can be stopped by emitting the `stop_log_stream` Socket.IO event. All active streams for a client are stopped on Socket.IO `disconnect`. |
+
+### Pipeline Pod Monitoring
+
+| ID | Requirement |
+|---|---|
+| FR-VPW9 | The service exposes filtered views of pipeline execution pods by status: `GET /api/pipeline-pods` (all), `/running`, `/pending`, `/success`, `/failed`, `/inactive`. |
+
+### Health
+
+| ID | Requirement |
+|---|---|
+| FR-VPW10 | A health check is available at `GET /health`. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-VPW1 | Log streaming runs in a per-client background thread. A `threading.Event` stop flag per Socket.IO session allows clean thread shutdown on disconnect or explicit stop. |
+| NFR-VPW2 | The service connects to Kubernetes using in-cluster config (`load_incluster_config`) when running in the cluster, falling back to `load_kube_config` for local development. |
+| NFR-VPW3 | Watched namespaces are fixed to `vibe-apps`, `vibe-mcp`, and `vibe-agents`. Namespace filtering per request is supported via the `namespace` query parameter. |
+| NFR-VPW4 | Socket.IO ping timeout is **300 seconds** to keep log streams open during long-running coding sessions. |

--- a/vs-extension/docs/ARCHITECTURE.md
+++ b/vs-extension/docs/ARCHITECTURE.md
@@ -1,0 +1,130 @@
+# VS Code Extension — Architecture
+
+---
+
+## 1. Service Architecture
+
+The extension runs entirely inside the **VS Code extension host** process. It has three main concerns: an OAuth module that handles the PKCE flow with a local HTTP callback server, a sidebar WebviewProvider that renders the UI, and a service layer that calls the Essedum backend REST API.
+
+```mermaid
+graph TB
+    subgraph VS Code Extension Host
+        EXT["extension.ts\nActivate · Register commands · Register providers"]
+        AUTH["Auth Module\nauth/\nPKCE flow · Token store\nToken refresh · Logout"]
+        CALLBACK["Local OAuth Callback Server\nlocalhost:8085 (configurable)"]
+        SIDEBAR["Sidebar Provider\nproviders/\nWebview panel rendering"]
+        PIPELINE_SVC["Pipeline Service\nservices/pipeline.service.ts\nList, submit, status"]
+        AGENT_SVC["Agent Pipeline Service\nservices/pipeline-agent.service.ts"]
+        API["HTTP API Client\nBearer token injection"]
+        SETTINGS["VS Code Settings\nessedum.serverUrl"]
+    end
+
+    subgraph External
+        BROWSER["System Browser\nKeycloak login page"]
+        KC["Keycloak\nOAuth2 / OIDC"]
+        BACKEND["Essedum Backend\n(REST API)"]
+    end
+
+    EXT --> AUTH & SIDEBAR
+    AUTH --> CALLBACK
+    AUTH -->|Open login URL| BROWSER
+    BROWSER --> KC
+    KC -->|Redirect with code| CALLBACK
+    AUTH --> API
+    SIDEBAR --> PIPELINE_SVC & AGENT_SVC
+    PIPELINE_SVC --> API
+    AGENT_SVC --> API
+    API --> BACKEND
+    SETTINGS -.->|serverUrl| API
+```
+
+**Component responsibilities:**
+
+- **Auth Module** — generates PKCE code verifier/challenge, opens the Keycloak login URL in the system browser, starts the local callback server, exchanges the authorization code for tokens, stores tokens in `SecretStorage`, and schedules automatic token refresh.
+- **Local Callback Server** — a lightweight HTTP server listening on a configurable port. It receives the OAuth redirect from the browser, extracts the authorization code, and hands it to the auth module to complete the token exchange.
+- **Sidebar Provider** — registers a VS Code WebviewProvider that renders the Essedum UI panel in the Activity Bar. Communicates with the extension host via VS Code's `postMessage` API.
+- **Pipeline / Agent Service** — thin service layer wrapping the Essedum REST API with typed methods for listing, submitting, and monitoring pipelines.
+- **HTTP API Client** — attaches the current Bearer token to every outbound request. Triggers token refresh if a 401 is received.
+
+---
+
+## 2. Dependency Map
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| Essedum Backend | External (HTTPS) | Pipeline list, job submission, execution status and logs |
+| Keycloak | External (HTTPS) | OAuth 2.0 authorization endpoint and token endpoint |
+| VS Code `SecretStorage` | VS Code API | Secure token persistence — survives VS Code restarts |
+| VS Code `WebviewProvider` | VS Code API | Sidebar UI rendering |
+| Local HTTP server (port 8085) | Local | OAuth PKCE callback receiver |
+
+---
+
+## 3. Architectural Decisions
+
+### AD-EXT1 — PKCE flow (no client secret)
+**Decision:** Authentication uses OAuth 2.0 Authorization Code flow with PKCE. No client secret is embedded in the extension.
+**Reason:** VS Code extensions are distributed as VSIX packages and run on user machines — a client secret would be visible to anyone who unpacks the extension. PKCE allows a public client to authenticate securely without a secret, using a per-session code verifier/challenge pair.
+
+### AD-EXT2 — Local HTTP callback server for OAuth redirect
+**Decision:** The extension starts a local HTTP server to receive the OAuth redirect instead of using a custom URI scheme.
+**Reason:** Custom URI scheme redirects (`vscode://...`) require OS-level registration which is not reliably available across all platforms. A local HTTP server on a configurable port (`localhost:8085`) works universally and is explicitly allowed by Keycloak's redirect URI configuration.
+
+### AD-EXT3 — Tokens stored in VS Code SecretStorage
+**Decision:** Access tokens and refresh tokens are stored using VS Code's `SecretStorage` API, not in `globalState` or workspace settings.
+**Reason:** `SecretStorage` uses the OS credential manager (Keychain on macOS, Credential Vault on Windows, libsecret on Linux), providing encrypted at-rest storage. Storing tokens in `globalState` or settings would write them as plaintext to disk.
+
+---
+
+## 4. Architecturally Significant Flows
+
+### Flow 1 — OAuth 2.0 PKCE Authentication
+
+```mermaid
+sequenceDiagram
+    participant USER as User
+    participant EXT as Extension
+    participant SERVER as Local Callback Server :8085
+    participant BROWSER as System Browser
+    participant KC as Keycloak
+
+    USER->>EXT: Click Login (Command Palette / Sidebar)
+    EXT->>EXT: Generate code_verifier + code_challenge (PKCE)
+    EXT->>SERVER: Start local HTTP server
+    EXT->>BROWSER: Open Keycloak auth URL (code_challenge, redirect=localhost:8085)
+    BROWSER->>KC: User enters credentials
+    KC-->>BROWSER: Redirect to localhost:8085?code=AUTH_CODE
+    BROWSER->>SERVER: GET /?code=AUTH_CODE
+    SERVER->>EXT: Authorization code received
+    EXT->>KC: POST /token {code, code_verifier, client_id}
+    KC-->>EXT: {access_token, refresh_token, expires_in}
+    EXT->>EXT: Store tokens in SecretStorage
+    EXT->>SERVER: Stop callback server
+    EXT->>USER: Login complete — sidebar refreshes
+```
+
+### Flow 2 — Pipeline Job Submission
+
+```mermaid
+sequenceDiagram
+    participant USER as User (Sidebar)
+    participant SIDEBAR as Sidebar WebviewProvider
+    participant SVC as Pipeline Service
+    participant API as HTTP Client
+    participant BE as Essedum Backend
+
+    USER->>SIDEBAR: Fill form + click Submit
+    SIDEBAR->>SVC: submitJob(pipelineId, params)
+    SVC->>API: POST /api/aip/jobs/run {pipelineId, params}
+    API->>API: Attach Bearer token
+    API->>BE: POST /api/aip/jobs/run
+    BE-->>API: 202 Accepted {executionId}
+    API-->>SVC: executionId
+    SVC-->>SIDEBAR: Update UI (running...)
+    loop Poll until terminal
+        SVC->>API: GET /api/aip/jobs/{executionId}/status
+        API->>BE: GET status
+        BE-->>API: status, logs
+        SVC-->>SIDEBAR: Update UI (log lines, status)
+    end
+```

--- a/vs-extension/docs/SCOPE.md
+++ b/vs-extension/docs/SCOPE.md
@@ -1,0 +1,52 @@
+# VS Code Extension — Scope
+
+## Objective
+
+Provide a **VS Code extension** that integrates the Essedum AI Platform into the developer's editor. The extension enables authentication via OAuth 2.0/PKCE, pipeline browsing, job submission, and real-time execution monitoring — without leaving VS Code.
+
+---
+
+## Functional Requirements
+
+### Authentication
+
+| ID | Requirement |
+|---|---|
+| FR-EXT1 | Users can authenticate with the Essedum platform via OAuth 2.0 with PKCE (Proof Key for Code Exchange). The extension launches the system browser for the Keycloak login page and receives the authorization code via a local callback server. |
+| FR-EXT2 | Access tokens are refreshed automatically before expiry. Users do not need to re-authenticate during a session. |
+| FR-EXT3 | Users can log out, which clears the stored tokens from VS Code's secret storage. |
+| FR-EXT4 | The local OAuth callback server port is configurable (default: 8085). |
+
+### Pipeline Browsing
+
+| ID | Requirement |
+|---|---|
+| FR-EXT5 | Users can browse available pipelines on the Essedum platform from a sidebar panel in the VS Code Activity Bar. |
+| FR-EXT6 | Pipelines are grouped and displayed with their name, type, and current status. |
+
+### Job Submission & Monitoring
+
+| ID | Requirement |
+|---|---|
+| FR-EXT7 | Users can submit a pipeline job directly from VS Code, specifying execution parameters via a UI form in the sidebar. |
+| FR-EXT8 | Real-time execution status (running, completed, failed) and logs are displayed in the sidebar without requiring the user to open a browser. |
+| FR-EXT9 | All API calls to the Essedum backend include the current Bearer token as the `Authorization` header. |
+
+### VS Code Integration
+
+| ID | Requirement |
+|---|---|
+| FR-EXT10 | The extension registers a custom sidebar view accessible from the VS Code Activity Bar via an Essedum icon. |
+| FR-EXT11 | Extension commands are available via the VS Code Command Palette. |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| NFR-EXT1 | The extension requires VS Code **1.103.0 or higher**. |
+| NFR-EXT2 | OAuth tokens are stored in VS Code's built-in **SecretStorage** API — never written to disk or settings files. |
+| NFR-EXT3 | PKCE code verifier and challenge are generated per authentication session — no static secrets are stored in the extension bundle. |
+| NFR-EXT4 | The extension is built with TypeScript and webpack. It runs in the VS Code **extension host** process, not the renderer. |
+| NFR-EXT5 | The backend server URL is configurable via VS Code settings (`essedum.serverUrl`) so the extension works with any Essedum deployment. |


### PR DESCRIPTION
…ices

- Move platform-level ARCHITECTURE.md and SCOPE.md into docs/ folder
- Add docs/SCOPE.md and docs/ARCHITECTURE.md with cross-service interaction flows
- Add sv/docs/SCOPE.md and sv/docs/ARCHITECTURE.md (backend overview)
- Add per-service docs for: api-gateway, usm-service, icip-service, data-service, vibe-service
- Add per-service docs for: agent-designer-backend, py-job-executer, py-job-sagemaker-executer, py-job-vertex-executer, py-job-azure-executer
- Add per-service docs for: nginx, proxy-service, s3proxy, vibe-pod-watcher, vibe-code-builder-deployer, adk-code-builder-deployer, vs-extension
- Add .github/agents/doc-agent.agent.md and .claude/agents/doc-agent.md (documentation agent)
- Add .github/workflows/openapi-spec.yml (auto-generate data-service OpenAPI spec)
- Enable Swagger UI for data-service: upgrade springdoc to v2.6.0, fix GroupedOpenApi import, whitelist Swagger paths in security config
- Add application-openapi.yml profile for spec generation with H2 in-memory DBs
- Update README.md links to point to docs/ subfolder