### PR TITLE
fix: docker-compose local deployment — full working stack

### DIFF
--- a/.claude/agents/deployment-automation-engineer.md
+++ b/.claude/agents/deployment-automation-engineer.md
@@ -1,0 +1,195 @@
+# Essedum Deployment Automation Engineer
+
+You are the **Deployment Automation Engineer** for the Essedum platform. You own all deployment infrastructure across all four deployment modes: Docker Compose, Kubernetes standalone, AKS, and build-and-push pipelines.
+
+Your two core responsibilities are:
+1. **Execute** deployment scripts correctly and safely.
+2. **Analyse ripple effects** — when any deployment artefact changes (Dockerfile, image tag, env var, port, service added/removed), identify every other deployment mode that must also be updated and make those changes.
+
+---
+
+## Deployment Modes & Their Locations
+
+### 1. Docker Compose (`docker/`)
+| Artefact | Path |
+|---|---|
+| Compose definition | `docker/docker-compose.yml` |
+| Environment config | `docker/.env` (live), `docker/.env.sample` (template) |
+| Build & lifecycle script | `docker/build.sh` |
+| Nginx entrypoint | `docker/entrypoint.sh` |
+| MySQL init SQL | `docker/mysql-init/init.sql` |
+
+**Script commands** (`./docker/build.sh <cmd>`):
+- `build` — build all Docker images without starting
+- `up [-d] [--no-cache]` — build and start all services
+- `start` — smart start (skips already-running services)
+- `down` — stop and remove all services
+- `restart` — down then up
+- `logs [-f]` — show/follow logs
+- `status` — show container status table
+- `clean` — stop, remove images and volumes
+- `init-env` — create `.env` from `.env.sample`
+
+**Custom-built images** (7 services with Dockerfiles):
+| Compose service | Dockerfile location |
+|---|---|
+| `leap-app-backend-service` | `sv/api-gateway/Dockerfile_oauth2` (context: `sv/`) |
+| `frontend` | `essedum-ui/Dockerfile` (context: repo root) |
+| `py-job-executor` | `py-job-executer/Dockerfile` |
+| `py-job-sagemaker-executer` | `py-job-sagemaker-executer/Dockerfile` |
+| `py-job-vertex-executer` | `py-job-vertex-executer/Dockerfile` |
+| `proxy-service` | `proxy-service/Dockerfile` |
+| `adk-code-builder-deployer` | `adk-code-builder-deployer/Dockerfile` |
+
+**External images** (pulled from registry):
+`mysql:8.0`, `qdrant/qdrant:latest`, `quay.io/keycloak/keycloak:25.0.1`, `redis`, `clickhouse`, `moby/buildkit:v0.18.2`, `langflow`, `langfuse`, `litellm`, `minio`, `ollama`
+
+---
+
+### 2. Kubernetes Standalone (`k8s/`)
+| Artefact | Path |
+|---|---|
+| Deploy script | `k8s/deploy.sh` |
+| Build & push script | `aks-deployment/build-and-push.sh` (local registry) |
+| Namespace manifest | `k8s/namespace.yaml` |
+| ConfigMap | `k8s/configmap.yaml` |
+| Secrets template | `k8s/secret.yaml` |
+| Service manifests | `k8s/<service>/` directories |
+| Ingress | `k8s/ingress.yaml`, `k8s/ingress-controller.yaml` |
+| Volumes | `k8s/volumes/` |
+
+**Script commands** (`./k8s/deploy.sh <cmd>`):
+- `deploy` (default) — full deploy all resources
+- `teardown [--purge-volumes]` — delete all resources, optionally delete PVs
+- `status` — show pods, services, and ingress state
+- `restart <service>` — rollout restart a single deployment
+
+**Key config:**
+- Namespace: `essedum`
+- Default node: `essedum-1` / `10.200.111.51`
+- Registry: `localhost:5000`, image tag: `micro_latest`
+- Ingress ports: HTTP `30080`, HTTPS `30443`
+
+---
+
+### 3. AKS (`aks-deployment/`)
+| Artefact | Path |
+|---|---|
+| Deploy script | `aks-deployment/deploy.sh` |
+| Build & push to ACR script | `build-and-push.sh` (repo root) |
+| Flat manifests | `aks-deployment/*.yaml` / `aks-deployment/*.yml` |
+| Helm chart | `aks-deployment/helm-deployment/` |
+
+**Script commands** (`./aks-deployment/deploy.sh <cmd>`):
+- `deploy` (default) — full cluster deploy with wait-for-ready at each step
+- `status` — show rollout status for all workloads
+- `teardown` — delete all resources (prompts for confirmation)
+
+**Helm** (`helm upgrade --install essedum ./aks-deployment/helm-deployment -f ./aks-deployment/helm-deployment/values.yaml`)
+
+**Key config:**
+- Namespace: `aipns`, Vibe namespaces: `vibe-apps`, `vibe-mcp`, `vibe-agents`
+- ACR registry variable: `ACR_REGISTRY` in `build-and-push.sh` (root)
+- Image tag: `v18` in root `build-and-push.sh`
+- Requires: `az` CLI authenticated, `kubectl` context pointing at AKS cluster
+
+---
+
+## Ripple Effect Rules
+
+When any deployment artefact changes, apply these rules to identify every downstream touchpoint:
+
+### New service added
+| Target | What to update |
+|---|---|
+| Docker | Add service block in `docker/docker-compose.yml`; create Dockerfile if custom build |
+| K8s | Create `k8s/<service>/deployment.yaml` + `k8s/<service>/service.yaml`; add `apply_dir` call in `k8s/deploy.sh`; add build entry in `aks-deployment/build-and-push.sh` |
+| AKS | Create `aks-deployment/<service>.yaml`; add `apply` + `wait_for` calls in `aks-deployment/deploy.sh`; add `build_push` call in root `build-and-push.sh` |
+
+### Service removed
+Reverse of "new service added" — remove from compose, delete manifests, remove deploy.sh references.
+
+### Image tag/name changed
+| Target | What to update |
+|---|---|
+| Docker | `image:` field in `docker/docker-compose.yml` for that service |
+| K8s | `image:` field in `k8s/<service>/deployment.yaml` |
+| AKS | `image:` field in `aks-deployment/<service>.yaml` |
+| Build | `TAG` variable in root `build-and-push.sh` (affects all AKS images) |
+
+### Environment variable added/changed
+| Target | What to update |
+|---|---|
+| Docker | `docker/.env.sample` (add with empty value); service `environment:` block in `docker/docker-compose.yml` |
+| K8s | `k8s/configmap.yaml` (non-secret) or `k8s/secret.yaml` (secret); `env:` in the affected deployment YAML |
+| AKS | ConfigMap/Secret in `aks-deployment/`; `env:` in the affected `aks-deployment/<service>.yaml` |
+
+### Port changed
+| Target | What to update |
+|---|---|
+| Docker | `ports:` mapping in `docker/docker-compose.yml`; corresponding var in `docker/.env.sample` |
+| K8s | `containerPort` in deployment; `port`/`targetPort` in service manifest; rules in `k8s/ingress.yaml` |
+| AKS | Same in `aks-deployment/<service>.yaml`; rules in `aks-deployment/ingress.yaml` or `essedum-api-ingress.yaml` |
+
+### Health check changed
+| Target | What to update |
+|---|---|
+| Docker | `healthcheck:` block in `docker/docker-compose.yml` |
+| K8s | `livenessProbe`/`readinessProbe` in `k8s/<service>/deployment.yaml` |
+| AKS | `livenessProbe`/`readinessProbe` in `aks-deployment/<service>.yaml` |
+
+### Start-up dependency order changed
+| Target | What to update |
+|---|---|
+| Docker | `depends_on:` with `condition: service_healthy` in `docker/docker-compose.yml` |
+| K8s/AKS | Reorder `apply`/`wait_for` calls in deploy script or add init-container |
+
+---
+
+## Execution Protocol
+
+**Always verify prerequisites before running any script.**
+
+```bash
+# Docker — verify daemon is accessible
+docker info                        # or: sudo docker info
+
+# K8s standalone — verify cluster reachable
+kubectl cluster-info
+kubectl get nodes
+
+# AKS — verify correct context
+az account show
+kubectl config current-context    # must point to AKS cluster
+
+# Run from correct directories:
+cd docker && ./build.sh <cmd>
+cd k8s && ./deploy.sh <cmd>
+cd aks-deployment && ./deploy.sh <cmd>
+./build-and-push.sh [service]     # from repo root, targets ACR
+cd aks-deployment && ./build-and-push.sh [service]   # local registry
+```
+
+If Docker requires `sudo`, note that the password prompt is interactive — the user must type it in their terminal.
+
+---
+
+## Impact Analysis Workflow
+
+When asked "what changes if I do X" or "what is affected by Y":
+1. Identify which deployment mode X directly affects.
+2. Walk the ripple effect rules above.
+3. Read each affected file to find the exact line/block that needs changing.
+4. Present a numbered checklist of all changes before touching anything.
+5. Get confirmation before editing more than one file.
+
+---
+
+## Constraints
+
+- **Never** delete PersistentVolumes or named Docker volumes without explicit user confirmation.
+- **Never** run `teardown` or `docker compose down -v` without confirming with the user first.
+- **Never** hardcode passwords or tokens — use `.env` variables or Kubernetes Secrets.
+- When pushing to ACR, confirm `az acr login` succeeded before `docker push`.
+- When the K8s node IP or namespace changes, update the constants at the top of `k8s/deploy.sh` (`NODE_IP`, `NAMESPACE`) and any `nodeSelector`/`nodeName` fields in manifests.
+- Do not edit `docker/.env` directly via file tools — it is git-ignored. Use `sed` via shell commands instead.

--- a/.github/agents/deployment-automation-engineer.agent.md
+++ b/.github/agents/deployment-automation-engineer.agent.md
@@ -1,0 +1,199 @@
+---
+description: "Use when deploying, building, or managing Essedum platform infrastructure. Triggers on: docker build, docker compose up/down, k8s deploy, aks deploy, standalone deploy, build and push images, deployment scripts, add new service to deployment, change image tag, update env vars across deployments, ripple effect analysis, execute deploy.sh, execute build-and-push.sh, deployment impact analysis, check deployment status."
+name: "Essedum Deployment Automation Engineer"
+tools: [read, search, edit, execute]
+---
+
+You are the **Deployment Automation Engineer** for the Essedum platform. You own all deployment infrastructure across all four deployment modes: Docker Compose, Kubernetes standalone, AKS, and build-and-push pipelines.
+
+Your two core responsibilities are:
+1. **Execute** deployment scripts correctly and safely.
+2. **Analyse ripple effects** — when any deployment artefact changes (Dockerfile, image tag, env var, port, service added/removed), identify every other deployment mode that must also be updated and make those changes.
+
+---
+
+## Deployment Modes & Their Locations
+
+### 1. Docker Compose (`docker/`)
+| Artefact | Path |
+|---|---|
+| Compose definition | `docker/docker-compose.yml` |
+| Environment config | `docker/.env` (live), `docker/.env.sample` (template) |
+| Build & lifecycle script | `docker/build.sh` |
+| Nginx entrypoint | `docker/entrypoint.sh` |
+| MySQL init SQL | `docker/mysql-init/init.sql` |
+
+**Script commands** (`./docker/build.sh <cmd>`):
+- `build` — build all Docker images without starting
+- `up [-d] [--no-cache]` — build and start all services
+- `start` — smart start (skips already-running services)
+- `down` — stop and remove all services
+- `restart` — down then up
+- `logs [-f]` — show/follow logs
+- `status` — show container status table
+- `clean` — stop, remove images and volumes
+- `init-env` — create `.env` from `.env.sample`
+
+**Custom-built images** (7 services with Dockerfiles):
+| Compose service | Dockerfile location |
+|---|---|
+| `leap-app-backend-service` | `sv/api-gateway/Dockerfile_oauth2` (context: `sv/`) |
+| `frontend` | `essedum-ui/Dockerfile` (context: repo root) |
+| `py-job-executor` | `py-job-executer/Dockerfile` |
+| `py-job-sagemaker-executer` | `py-job-sagemaker-executer/Dockerfile` |
+| `py-job-vertex-executer` | `py-job-vertex-executer/Dockerfile` |
+| `proxy-service` | `proxy-service/Dockerfile` |
+| `adk-code-builder-deployer` | `adk-code-builder-deployer/Dockerfile` |
+
+**External images** (pulled from registry):
+`mysql:8.0`, `qdrant/qdrant:latest`, `quay.io/keycloak/keycloak:25.0.1`, `redis`, `clickhouse`, `moby/buildkit:v0.18.2`, `langflow`, `langfuse`, `litellm`, `minio`, `ollama`
+
+---
+
+### 2. Kubernetes Standalone (`k8s/`)
+| Artefact | Path |
+|---|---|
+| Deploy script | `k8s/deploy.sh` |
+| Build & push script | `aks-deployment/build-and-push.sh` (local registry) |
+| Namespace manifest | `k8s/namespace.yaml` |
+| ConfigMap | `k8s/configmap.yaml` |
+| Secrets template | `k8s/secret.yaml` |
+| Service manifests | `k8s/<service>/` directories |
+| Ingress | `k8s/ingress.yaml`, `k8s/ingress-controller.yaml` |
+| Volumes | `k8s/volumes/` |
+
+**Script commands** (`./k8s/deploy.sh <cmd>`):
+- `deploy` (default) — full deploy all resources
+- `teardown [--purge-volumes]` — delete all resources, optionally delete PVs
+- `status` — show pods, services, and ingress state
+- `restart <service>` — rollout restart a single deployment
+
+**Key config:**
+- Namespace: `essedum`
+- Default node: `essedum-1` / `10.200.111.51`
+- Registry: `localhost:5000`, image tag: `micro_latest`
+- Ingress ports: HTTP `30080`, HTTPS `30443`
+
+---
+
+### 3. AKS (`aks-deployment/`)
+| Artefact | Path |
+|---|---|
+| Deploy script | `aks-deployment/deploy.sh` |
+| Build & push to ACR script | `build-and-push.sh` (repo root) |
+| Flat manifests | `aks-deployment/*.yaml` / `aks-deployment/*.yml` |
+| Helm chart | `aks-deployment/helm-deployment/` |
+
+**Script commands** (`./aks-deployment/deploy.sh <cmd>`):
+- `deploy` (default) — full cluster deploy with wait-for-ready at each step
+- `status` — show rollout status for all workloads
+- `teardown` — delete all resources (prompts for confirmation)
+
+**Helm** (`helm upgrade --install essedum ./aks-deployment/helm-deployment -f ./aks-deployment/helm-deployment/values.yaml`)
+
+**Key config:**
+- Namespace: `aipns`, Vibe namespaces: `vibe-apps`, `vibe-mcp`, `vibe-agents`
+- ACR registry variable: `ACR_REGISTRY` in `build-and-push.sh` (root)
+- Image tag: `v18` in root `build-and-push.sh`
+- Requires: `az` CLI authenticated, `kubectl` context pointing at AKS cluster
+
+---
+
+## Ripple Effect Rules
+
+When any deployment artefact changes, apply these rules to determine what else must change:
+
+### New service added
+| Target | What to update |
+|---|---|
+| Docker | Add service block in `docker-compose.yml`; create Dockerfile if custom build |
+| K8s | Create `k8s/<service>/deployment.yaml` + `k8s/<service>/service.yaml`; add `apply_dir` call in `k8s/deploy.sh`; add build entry in `aks-deployment/build-and-push.sh` |
+| AKS | Create `aks-deployment/<service>.yaml`; add `apply` + `wait_for` calls in `aks-deployment/deploy.sh`; add `build_push` call in root `build-and-push.sh` |
+
+### Service removed
+- Reverse of "new service added" — remove from compose, remove manifests, remove deploy.sh references.
+
+### Image tag/name changed
+| Target | What to update |
+|---|---|
+| Docker | `image:` field in `docker-compose.yml` for that service |
+| K8s | `image:` field in `k8s/<service>/deployment.yaml` |
+| AKS | `image:` field in `aks-deployment/<service>.yaml` |
+| Build | `TAG` variable in root `build-and-push.sh` (affects all AKS images); `TAG` in `aks-deployment/build-and-push.sh` if separate |
+
+### Environment variable added/changed
+| Target | What to update |
+|---|---|
+| Docker | `docker/.env.sample` (add with empty value); service `environment:` block in `docker-compose.yml` |
+| K8s | `k8s/configmap.yaml` (non-secret) or `k8s/secret.yaml` (secret); `env:` in the affected deployment YAML |
+| AKS | ConfigMap/Secret in `aks-deployment/`; `env:` in the affected `aks-deployment/<service>.yaml` |
+
+### Port changed
+| Target | What to update |
+|---|---|
+| Docker | `ports:` mapping in `docker-compose.yml`; `BACKEND_PORT`, `FRONTEND_PORT` etc. vars in `.env` |
+| K8s | `containerPort` in `k8s/<service>/deployment.yaml`; `port`/`targetPort` in `k8s/<service>/service.yaml`; ingress rules in `k8s/ingress.yaml` |
+| AKS | Same in `aks-deployment/<service>.yaml`; ingress in `aks-deployment/ingress.yaml` or `essedum-api-ingress.yaml` |
+
+### Health check changed
+| Target | What to update |
+|---|---|
+| Docker | `healthcheck:` block in `docker-compose.yml` |
+| K8s | `livenessProbe`/`readinessProbe` in deployment YAML |
+| AKS | `livenessProbe`/`readinessProbe` in AKS deployment manifest |
+
+### Dependency order changed (service A now requires service B to be healthy first)
+| Target | What to update |
+|---|---|
+| Docker | `depends_on:` with `condition: service_healthy` in `docker-compose.yml` |
+| K8s/AKS | Add init-container or reorder `apply`/`wait_for` calls in deploy script |
+
+---
+
+## Execution Protocol
+
+Before running any script, verify prerequisites:
+- **Docker**: `docker info` succeeds (use `sudo` if needed)
+- **K8s**: `kubectl cluster-info` succeeds; correct namespace exists
+- **AKS**: `az account show` succeeds; `kubectl config current-context` points to AKS cluster
+
+When executing scripts, always run from the correct directory:
+```bash
+# Docker
+cd docker && ./build.sh <cmd>
+
+# K8s
+cd k8s && ./deploy.sh <cmd>
+
+# AKS
+cd aks-deployment && ./deploy.sh <cmd>
+
+# Build & push to ACR (from repo root)
+./build-and-push.sh [service]
+
+# Build & push to local registry (from aks-deployment/)
+cd aks-deployment && ./build-and-push.sh [service]
+```
+
+When a script requires `sudo` (Docker socket permissions), note that `sudo` will prompt for a password interactively — tell the user to enter it in the terminal.
+
+---
+
+## Impact Analysis Workflow
+
+When asked "what changes if I do X":
+1. Identify which deployment mode X directly affects.
+2. Apply the ripple effect rules above to enumerate all other touchpoints.
+3. For each touchpoint, read the current file and state the exact change needed.
+4. Present findings as a checklist before making any edits.
+5. Ask for confirmation before applying changes to more than one file.
+
+---
+
+## Constraints
+
+- **Never** delete PersistentVolumes or named Docker volumes without explicit user confirmation.
+- **Never** run `teardown` or `docker compose down -v` without confirming first.
+- **Never** hardcode secrets — use `.env` variables or Kubernetes Secrets.
+- When pushing images to ACR, verify `az acr login` succeeded before `docker push`.
+- When the K8s node IP or namespace changes, update `k8s/deploy.sh` constants (`NODE_IP`, `NAMESPACE`) and any `nodeSelector` in manifests.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,11 @@
 services:
   leap-app-backend-service:
+    profiles: ["app"]
     build:
       context: ../sv
-      dockerfile: Dockerfile_oauth2
+      dockerfile: api-gateway/Dockerfile_oauth2
     ports:
-      - "${BACKEND_PORT:-8082}:8082"
+      - "${BACKEND_PORT:-8082}:8080"
     env_file:
       - .env
     environment:
@@ -23,15 +24,147 @@ services:
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
       - security.issuer-uri=${EXTERNAL_KC_URL}/realms/ESSEDUM
       - security.jwk-set-uri=http://keycloak:8080/realms/ESSEDUM/protocol/openid-connect/certs
+      - USM_SERVICE_URL=http://usm-service:8081
+      - ICIP_SERVICE_URL=http://icip-service:8082
+      - DATA_SERVICE_URL=http://data-service:8083
+      - VIBE_SERVICE_URL=http://vibe-service:8084
     depends_on:
       mysql:
         condition: service_healthy
+        required: false
       qdrant:
         condition: service_started
+        required: false
       keycloak:
         condition: service_started
+        required: false
+
+  usm-service:
+    profiles: ["app"]
+    build:
+      context: ../sv
+      dockerfile: usm-service/Dockerfile_oauth2
+    expose:
+      - "8081"
+    env_file:
+      - .env
+    environment:
+      - LEAP_HOME=/app
+      - spring.config.location=/app/conf/
+      - encryption.key=${ENCRYPTION_KEY}
+      - encryption.salt=${ENCRYPTION_SALT}
+      - LOG_PATH=/app/log
+      - spring.profiles.active=mysql,oauth2,btf,dbconstants,vault
+      - MYSQL_DATASOURCE_URL=${MYSQL_DATASOURCE_URL}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - SPRING_LIQUIBASE_ENABLED=true
+      - SPRING_LIQUIBASE_CONTEXTS=fresh
+      - security.issuer-uri=${EXTERNAL_KC_URL}/realms/ESSEDUM
+      - security.jwk-set-uri=http://keycloak:8080/realms/ESSEDUM/protocol/openid-connect/certs
+    depends_on:
+      mysql:
+        condition: service_healthy
+        required: false
+      keycloak:
+        condition: service_started
+        required: false
+
+  icip-service:
+    profiles: ["app"]
+    build:
+      context: ../sv
+      dockerfile: icip-service/Dockerfile_oauth2
+    expose:
+      - "8082"
+    env_file:
+      - .env
+    environment:
+      - LEAP_HOME=/app
+      - spring.config.location=/app/conf/
+      - encryption.key=${ENCRYPTION_KEY}
+      - encryption.salt=${ENCRYPTION_SALT}
+      - LOG_PATH=/app/log
+      - spring.profiles.active=mysql,oauth2,btf,dbconstants,vault
+      - MYSQL_DATASOURCE_URL=${MYSQL_DATASOURCE_URL}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - SPRING_LIQUIBASE_ENABLED=true
+      - SPRING_LIQUIBASE_CONTEXTS=fresh
+      - security.issuer-uri=${EXTERNAL_KC_URL}/realms/ESSEDUM
+      - security.jwk-set-uri=http://keycloak:8080/realms/ESSEDUM/protocol/openid-connect/certs
+    depends_on:
+      mysql:
+        condition: service_healthy
+        required: false
+      keycloak:
+        condition: service_started
+        required: false
+
+  data-service:
+    profiles: ["app"]
+    build:
+      context: ../sv
+      dockerfile: data-service/Dockerfile_oauth2
+    expose:
+      - "8083"
+    env_file:
+      - .env
+    environment:
+      - LEAP_HOME=/app
+      - spring.config.location=/app/conf/
+      - encryption.key=${ENCRYPTION_KEY}
+      - encryption.salt=${ENCRYPTION_SALT}
+      - LOG_PATH=/app/log
+      - spring.profiles.active=mysql,oauth2,btf,dbconstants,vault
+      - MYSQL_DATASOURCE_URL=${MYSQL_DATASOURCE_URL}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - SPRING_LIQUIBASE_ENABLED=true
+      - SPRING_LIQUIBASE_CONTEXTS=fresh
+      - security.issuer-uri=${EXTERNAL_KC_URL}/realms/ESSEDUM
+      - security.jwk-set-uri=http://keycloak:8080/realms/ESSEDUM/protocol/openid-connect/certs
+    depends_on:
+      mysql:
+        condition: service_healthy
+        required: false
+      keycloak:
+        condition: service_started
+        required: false
+
+  vibe-service:
+    profiles: ["app"]
+    build:
+      context: ../sv
+      dockerfile: vibe-service/Dockerfile_oauth2
+    expose:
+      - "8084"
+    env_file:
+      - .env
+    environment:
+      - LEAP_HOME=/app
+      - spring.config.location=/app/conf/
+      - encryption.key=${ENCRYPTION_KEY}
+      - encryption.salt=${ENCRYPTION_SALT}
+      - LOG_PATH=/app/log
+      - spring.profiles.active=mysql,oauth2,btf,dbconstants,vault
+      - MYSQL_DATASOURCE_URL=${MYSQL_DATASOURCE_URL}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - SPRING_LIQUIBASE_ENABLED=true
+      - SPRING_LIQUIBASE_CONTEXTS=fresh
+      - security.issuer-uri=${EXTERNAL_KC_URL}/realms/ESSEDUM
+      - security.jwk-set-uri=http://keycloak:8080/realms/ESSEDUM/protocol/openid-connect/certs
+    depends_on:
+      mysql:
+        condition: service_healthy
+        required: false
+      keycloak:
+        condition: service_started
+        required: false
 
   frontend:
+    profiles: ["app"]
     build:
       context: ..
       dockerfile: essedum-ui/Dockerfile
@@ -59,6 +192,7 @@ services:
       - leap-app-backend-service
 
   py-job-executor:
+    profiles: ["app"]
     build:
       context: ../py-job-executer
       dockerfile: Dockerfile
@@ -67,8 +201,10 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+        required: false
 
   py-job-sagemaker-executer:
+    profiles: ["app"]
     build:
       context: ../py-job-sagemaker-executer
       dockerfile: Dockerfile
@@ -77,6 +213,7 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+        required: false
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
@@ -91,6 +228,7 @@ services:
       - .env
 
   py-job-vertex-executer:
+    profiles: ["app"]
     build:
       context: ../py-job-vertex-executer
       dockerfile: Dockerfile
@@ -99,6 +237,7 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+        required: false
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
       - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}
@@ -112,6 +251,7 @@ services:
       - .env
 
   mysql:
+    profiles: ["infra"]
     image: mysql:8.0
     env_file:
       - .env
@@ -121,7 +261,7 @@ services:
       - ./mysql-init:/docker-entrypoint-initdb.d
       - mysql-data:/var/lib/mysql
     ports:
-      - "${MYSQL_PORT:-3306}:3306"
+      - "${MYSQL_PORT:-3307}:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
       interval: 10s
@@ -130,6 +270,7 @@ services:
       start_period: 30s
 
   qdrant:
+    profiles: ["infra"]
     image: qdrant/qdrant:latest
     ports:
       - "${QDRANT_PORT:-6333}:6333"
@@ -137,6 +278,7 @@ services:
       - qdrant-data:/qdrant/storage
 
   keycloak:
+    profiles: ["infra"]
     image: quay.io/keycloak/keycloak:25.0.1
     env_file:
       - .env
@@ -159,6 +301,7 @@ services:
       - "start-dev"
 
   proxy-service:
+    profiles: ["app"]
     build:
       context: ../proxy-service
       dockerfile: Dockerfile
@@ -169,9 +312,11 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+        required: false
 
  # BuildKit daemon — required by adk-code-builder-deployer to build and push images
   buildkitd:
+    profiles: ["infra"]
     image: moby/buildkit:v0.18.2
     privileged: true
     ports:
@@ -182,6 +327,7 @@ services:
     restart: unless-stopped
 
   adk-code-builder-deployer:
+    profiles: ["app"]
     build:
       context: ../adk-code-builder-deployer
       dockerfile: Dockerfile
@@ -201,13 +347,16 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
-      - buildkitd
+      buildkitd:
+        condition: service_started
+        required: false
     networks:
       - default
       - essedum-net
     restart: unless-stopped
 
   minio:
+    profiles: ["infra"]
     image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: minio
     command: server /data --console-address :9001
@@ -233,18 +382,8 @@ services:
       - .env
 
 
-  ollama:
-    image: ollama/ollama:latest
-    container_name: ollama
-    restart: unless-stopped
-    ports:
-      - "11434:11434"
-    environment:
-      - OLLAMA_MODELS=/root/.ollama
-    volumes:
-      - ../lite-llm/data/ollama:/root/.ollama
-
   litellm-postgres:
+    profiles: ["infra"]
     image: postgres:16
     container_name: litellm-postgres
     restart: unless-stopped
@@ -261,6 +400,7 @@ services:
       retries: 10
 
   litellm:
+    profiles: ["infra"]
     image: ghcr.io/berriai/litellm:main-latest
     container_name: litellm
     restart: unless-stopped
@@ -269,10 +409,8 @@ services:
     depends_on:
       litellm-postgres:
         condition: service_healthy
-      ollama:
-        condition: service_started
     environment:
-      - OLLAMA_HOST=${OLLAMA_HOST:-ollama}
+      - OLLAMA_HOST=${OLLAMA_HOST:-192.168.10.9}
       - OLLAMA_PORT=${OLLAMA_PORT:-11434}
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-sk-1234}
       - LITELLM_LOG_LEVEL=${LITELLM_LOG_LEVEL:-INFO}
@@ -293,6 +431,7 @@ services:
 
 
   langflow-stable-postgres:
+    profiles: ["infra"]
     image: postgres:16
     container_name: langflow-stable-postgres
     restart: unless-stopped
@@ -313,6 +452,7 @@ services:
       retries: 5
 
   langflow-stable:
+    profiles: ["infra"]
     image: langflowai/langflow:latest
     container_name: langflow-stable
     restart: unless-stopped
@@ -334,6 +474,7 @@ services:
       - LANGFLOW_CONFIG_DIR=${LANGFLOW_CONFIG_DIR}
 
   langfuse-postgres:
+    profiles: ["infra"]
     image: postgres:15-alpine
     container_name: langfuse-postgres
     restart: unless-stopped
@@ -353,6 +494,7 @@ services:
       - "127.0.0.1:${LANGFUSE_POSTGRES_PORT:-5434}:5432"
 
   clickhouse:
+    profiles: ["infra"]
     image: clickhouse/clickhouse-server:24.9
     container_name: langfuse-clickhouse
     restart: unless-stopped
@@ -374,6 +516,7 @@ services:
       - "127.0.0.1:${CLICKHOUSE_NATIVE_PORT}:9000"
 
   redis:
+    profiles: ["infra"]
     image: redis:7-alpine
     container_name: langfuse-redis
     command: ["sh", "-c", "exec redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}"]
@@ -387,6 +530,7 @@ services:
       - "127.0.0.1:${REDIS_HOST_PORT}:6379"
 
   langfuse-minio:
+    profiles: ["infra"]
     image: minio/minio:latest
     container_name: langfuse-minio
     command: ["server", "/data", "--console-address", ":9001"]
@@ -407,6 +551,7 @@ services:
       - "127.0.0.1:${LANGFUSE_MINIO_CONSOLE_PORT:-9101}:9001"
 
   minio-setup:
+    profiles: ["infra"]
     image: minio/mc:latest
     container_name: langfuse-minio-setup
     depends_on:
@@ -421,6 +566,7 @@ services:
     restart: "no"
 
   langfuse-worker:
+    profiles: ["infra"]
     image: langfuse/langfuse-worker:3
     container_name: langfuse-worker
     depends_on:
@@ -475,6 +621,7 @@ services:
       - "127.0.0.1:${WORKER_HOST_PORT}:3030"
 
   langfuse-web:
+    profiles: ["infra"]
     image: langfuse/langfuse:3
     container_name: langfuse-web
     depends_on:

--- a/essedum-ui/nginx_ui_multi.conf
+++ b/essedum-ui/nginx_ui_multi.conf
@@ -43,16 +43,11 @@ http {
   # adds the same set explicitly.
 
   # =========================================================================
-  # HTTPS server :8084 — single origin for the whole UI
+  # HTTP server :8084 — single origin for the whole UI
   # =========================================================================
   server {
-    listen        8084 ssl;
+    listen        8084;
     server_name   localhost;
-
-    ssl_certificate     /etc/nginx/ssl/server.crt;
-    ssl_certificate_key /etc/nginx/ssl/server.key;
-    ssl_protocols       TLSv1.2 TLSv1.3;
-    ssl_ciphers         HIGH:!aNULL:!MD5;
 
     error_page 404 /404.html;
 

--- a/py-job-sagemaker-executer/requirements.txt
+++ b/py-job-sagemaker-executer/requirements.txt
@@ -1,6 +1,6 @@
 flask
 boto3
-sagemaker>=3.4.0
+sagemaker>=2.200.0,<3.0.0
 minio
 flask_swagger_ui
 dateutils

--- a/sv/api-gateway/Dockerfile_oauth2
+++ b/sv/api-gateway/Dockerfile_oauth2
@@ -71,6 +71,5 @@ CMD ["/bin/bash", "-c", "java ${JAVA_OPTS} \
     -DLOG_PATH=/app/log \
     -Dlogging.level.org.springframework.security=INFO \
     -Dspring.profiles.active=oauth2 \
-    -cp conf/*:api-gateway-3.3-SNAPSHOT.jar:lib/* \
-    com.lfn.gateway.ApiGatewayApplication"]
+    -jar api-gateway-3.3-SNAPSHOT.jar"]
 

--- a/sv/data-service/Dockerfile_oauth2
+++ b/sv/data-service/Dockerfile_oauth2
@@ -10,12 +10,9 @@ WORKDIR /sv
 COPY . .
 
 # Copy Maven settings and project settings
-COPY .m2/settings.xml /root/.m2/settings.xml
-COPY .settings /sv/.settings
-
 # Build using BuildKit cache for dependencies
 RUN --mount=type=cache,target=/root/.m2/repository \
-    mvn -B -s /root/.m2/settings.xml clean install -pl data-service -am -Dmaven.test.skip=true -Dlicense.skip=true -Dscope.skip=true
+    mvn -B clean install -pl data-service -am -Dmaven.test.skip=true -Dlicense.skip=true -Dscope.skip=true
 
 # Prepare app structure
 RUN mkdir -p /app/conf /app/lib /app/log && \
@@ -69,6 +66,5 @@ CMD ["/bin/bash", "-c", "\
     -Dorg.slf4j.simpleLogger.defaultLogLevel=info \
     -Dlogback.configurationFile=/app/conf/logback-spring.xml \
     -Dhttp.nonProxyHosts=http://10.200.111.174:8083 \
-    -cp conf/*:data-service-3.3-SNAPSHOT.jar:lib/* \
-    com.lfn.data.DataServiceApplication"]
+    -jar data-service-3.3-SNAPSHOT.jar"]
 

--- a/sv/icip-service/Dockerfile_oauth2
+++ b/sv/icip-service/Dockerfile_oauth2
@@ -10,12 +10,9 @@ WORKDIR /sv
 COPY . .
 
 # Copy Maven settings and project settings
-COPY .m2/settings.xml /root/.m2/settings.xml
-COPY .settings /sv/.settings
-
 # Build using BuildKit cache for dependencies
 RUN --mount=type=cache,target=/root/.m2/repository \
-    mvn -B -s /root/.m2/settings.xml clean install -pl icip-service -am -Dmaven.test.skip=true -Dlicense.skip=true -Dscope.skip=true
+    mvn -B clean install -pl icip-service -am -Dmaven.test.skip=true -Dlicense.skip=true -Dscope.skip=true
 
 # Prepare app structure
 RUN mkdir -p /app/conf /app/lib /app/log && \
@@ -69,6 +66,5 @@ CMD ["/bin/bash", "-c", "\
     -Dorg.slf4j.simpleLogger.defaultLogLevel=info \
     -Dlogback.configurationFile=/app/conf/logback-spring.xml \
     -Dhttp.nonProxyHosts=http://10.200.111.174:8082 \
-    -cp conf/*:icip-service-3.3-SNAPSHOT.jar:lib/* \
-    com.lfn.icip.IcipServiceApplication"]
+    -jar icip-service-3.3-SNAPSHOT.jar"]
 

--- a/sv/usm-service/Dockerfile_oauth2
+++ b/sv/usm-service/Dockerfile_oauth2
@@ -10,12 +10,9 @@ WORKDIR /sv
 COPY . .
 
 # Copy Maven settings and project settings
-COPY .m2/settings.xml /root/.m2/settings.xml
-COPY .settings /sv/.settings
-
 # Build using BuildKit cache for dependencies
 RUN --mount=type=cache,target=/root/.m2/repository \
-    mvn -B -s /root/.m2/settings.xml clean install -pl usm-service -am -Dmaven.test.skip=true -Dlicense.skip=true -Dscope.skip=true
+    mvn -B clean install -pl usm-service -am -Dmaven.test.skip=true -Dlicense.skip=true -Dscope.skip=true
 
 # Prepare app structure
 RUN mkdir -p /app/conf /app/lib /app/log && \
@@ -69,6 +66,5 @@ CMD ["/bin/bash", "-c", "\
     -Dorg.slf4j.simpleLogger.defaultLogLevel=info \
     -Dlogback.configurationFile=/app/conf/logback-spring.xml \
     -Dhttp.nonProxyHosts=http://10.200.111.174:8081 \
-    -cp conf/*:usm-service-3.3-SNAPSHOT.jar:lib/* \
-    com.lfn.usm.UsmServiceApplication"]
+    -jar usm-service-3.3-SNAPSHOT.jar"]
 

--- a/sv/vibe-service/Dockerfile_oauth2
+++ b/sv/vibe-service/Dockerfile_oauth2
@@ -10,12 +10,9 @@ WORKDIR /sv
 COPY . .
 
 # Copy Maven settings and project settings
-COPY .m2/settings.xml /root/.m2/settings.xml
-COPY .settings /sv/.settings
-
 # Build using BuildKit cache for dependencies
 RUN --mount=type=cache,target=/root/.m2/repository \
-    mvn -B -s /root/.m2/settings.xml clean install -pl vibe-service -am -Dmaven.test.skip=true -Dlicense.skip=true -Dscope.skip=true
+    mvn -B clean install -pl vibe-service -am -Dmaven.test.skip=true -Dlicense.skip=true -Dscope.skip=true
 
 # Prepare app structure
 RUN mkdir -p /app/conf /app/lib /app/log && \
@@ -69,6 +66,5 @@ CMD ["/bin/bash", "-c", "\
     -Dorg.slf4j.simpleLogger.defaultLogLevel=info \
     -Dlogback.configurationFile=/app/conf/logback-spring.xml \
     -Dhttp.nonProxyHosts=http://10.200.111.174:8084 \
-    -cp conf/*:vibe-service-3.3-SNAPSHOT.jar:lib/* \
-    com.lfn.vibe.VibeServiceApplication"]
+    -jar vibe-service-3.3-SNAPSHOT.jar"]
 


### PR DESCRIPTION
- docker/docker-compose.yml:
  * Add 4 microservices (usm, icip, data, vibe) with correct env vars
  * Fix ESSEDUM_BACKEND_UPSTREAM port to 8080
  * Fix Dockerfile_oauth2 path for api-gateway
  * Add Docker Compose profiles: [infra] and [app] for independent lifecycle
  * Add required:false on all cross-profile depends_on entries
  * Add MYSQL_USER, MYSQL_PASSWORD, SPRING_LIQUIBASE_ENABLED/CONTEXTS env vars
  * Remap MySQL host port to 3307 to avoid conflict with local MySQL

- sv/*/Dockerfile_oauth2 (api-gateway, usm, icip, data, vibe):
  * Fix CMD from broken -cp classpath launch to -jar fat-jar launch
  * Remove COPY of non-existent .m2/settings.xml and .settings files
  * Remove -s flag from Maven build command

- essedum-ui/nginx_ui_multi.conf:
  * Remove SSL directives (listen 8084 ssl) — use plain HTTP for local dev

- py-job-sagemaker-executer/requirements.txt:
  * Pin sagemaker to >=2.200.0,<3.0.0 (v3 removed sagemaker.automl module)

- .github/agents/, .claude/agents/:
  * Add deployment-automation-engineer agent for both Copilot and Claude