### PR TITLE
feat: propagate pipeline cname through K8s annotation for pod-watcher sync

### DIFF
--- a/vibe-code-builder-deployer/app.py
+++ b/vibe-code-builder-deployer/app.py
@@ -405,6 +405,7 @@ def handle_pipeline_trigger(data):
         log_to_client("Download complete.", step="DOWNLOAD")
         #suffix = ''.join(random.choices(string.ascii_lowercase, k=5))
         deploy_name = data["deployment_name"]
+        cname = data.get("cname", deploy_name)   # original pipeline name before sanitization
 
         # Sanitize deployment name to meet Kubernetes DNS-1035 requirements:
         # - Must start with alphabetic character
@@ -632,7 +633,7 @@ def handle_pipeline_trigger(data):
                     "Deployment not found. Creating new deployment...", step="DEPLOY"
                 )
                 deployment_obj = create_deployment_object(
-                    deploy_name, image_tag, target_namespace, secret_to_use, container_port=detected_port
+                    deploy_name, image_tag, target_namespace, secret_to_use, container_port=detected_port, cname=cname
                 )
                 k8s_apps.create_namespaced_deployment(
                     namespace=target_namespace, body=deployment_obj
@@ -768,7 +769,7 @@ def _detect_app_port(directory, entry_point):
     return 5000
 
 
-def create_deployment_object(name, image, namespace, secret_name=None, container_port=5000):
+def create_deployment_object(name, image, namespace, secret_name=None, container_port=5000, cname=None):
     """Creates a V1Deployment object for the runner"""
 
     env_from = []
@@ -793,7 +794,10 @@ def create_deployment_object(name, image, namespace, secret_name=None, container
     )
 
     template = client.V1PodTemplateSpec(
-        metadata=client.V1ObjectMeta(labels={"app": name}),
+        metadata=client.V1ObjectMeta(
+            labels={"app": name},
+            annotations={"pipeline-cname": cname or name},
+        ),
         spec=client.V1PodSpec(
             containers=[container],
             image_pull_secrets=[client.V1LocalObjectReference(name="regcred")],

--- a/vibe-pod-watcher/app.py
+++ b/vibe-pod-watcher/app.py
@@ -497,6 +497,7 @@ def _build_pipeline_record(pod, cs, container_spec) -> dict:
         "pod_name":         pod.metadata.name,
         "container_name":   container_spec.name if container_spec else (cs.name if cs else ""),
         "deployment_name":  deployment_name,
+        "pipeline_name":    annotations.get("pipeline-cname") or deployment_name,
         "namespace":        ns,
         "type":             _namespace_to_type(ns),
         "description":      description,


### PR DESCRIPTION
Summary
vibe-code-builder-deployer — added cname param to create_deployment_object() and writes it as a pipeline-cname pod annotation at deploy time. The cname is read from the incoming payload (data.get("cname", deploy_name)) so the original pipeline name is preserved even after the deployment name is sanitized for Kubernetes DNS-1035 compliance.
vibe-pod-watcher — _build_pipeline_record() now reads the pipeline-cname annotation and exposes it as a pipeline_name field in the /api/pipeline-pods response, falling back to deployment_name when the annotation is absent (e.g. older pods).
Why
Pipeline containers in K8s had their names sanitized (lowercased, special chars stripped) to meet DNS naming rules, which caused the pod-watcher API to return a mangled name that couldn't be matched back to the original pipeline record in the DB. The annotation carries the canonical name through the full lifecycle without affecting K8s routing.